### PR TITLE
feat: added connection latency to charge point view

### DIFF
--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/entity/ChargePoint.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/entity/ChargePoint.kt
@@ -53,7 +53,9 @@ object ChargePointTable : LongIdTable("charge_point") {
     val apiUrl = varchar("api_url", 1024)
     val maxKw = double("max_kw")
 
-    val averageLatencyMillis = integer("average_latency_millis")
+    val messageCount = integer("message_count")
+        .default(0)
+    val averageLatencyMillis = long("average_latency_millis")
         .default(0)
 
     // Heartbeat
@@ -156,6 +158,7 @@ class ChargePointDAO(
     var maxKw by ChargePointTable.maxKw
 
     var averageLatencyMillis by ChargePointTable.averageLatencyMillis
+    var messageCount by ChargePointTable.messageCount
 
     var heartbeatAt by ChargePointTable.heartbeatAt
 

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/entity/ChargePoint.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/entity/ChargePoint.kt
@@ -53,6 +53,9 @@ object ChargePointTable : LongIdTable("charge_point") {
     val apiUrl = varchar("api_url", 1024)
     val maxKw = double("max_kw")
 
+    val averageLatencyMillis = integer("average_latency_millis")
+        .default(0)
+
     // Heartbeat
     val heartbeatAt = timestamp("heartbeat_at")
 
@@ -151,6 +154,8 @@ class ChargePointDAO(
     var ocppUrl by ChargePointTable.ocppUrl
     var apiUrl by ChargePointTable.apiUrl
     var maxKw by ChargePointTable.maxKw
+
+    var averageLatencyMillis by ChargePointTable.averageLatencyMillis
 
     var heartbeatAt by ChargePointTable.heartbeatAt
 

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/view/components/ChargePointComponent.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/view/components/ChargePointComponent.kt
@@ -63,7 +63,7 @@ fun chargePointComponent(
                     clipboardManager.setText(AnnotatedString(chargePoint.identity))
                 }
             )
-            Text("Latency: ${chargePoint.averageLatencyMillis}ms")
+            Text("Latency: ${chargePoint.averageLatencyMillis} ms (${chargePoint.messageCount})")
             Text("Status: ${chargePoint.status}")
             Text("Status At: ${chargePoint.statusAt.toReadable()}")
             Text("Firmware: ${chargePoint.firmware}")

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/view/components/ChargePointComponent.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/view/components/ChargePointComponent.kt
@@ -57,13 +57,13 @@ fun chargePointComponent(
                     modifier = Modifier.align(Alignment.CenterEnd)
                 )
             }
-
             Text(
                 "Identity: ${chargePoint.identity}",
                 modifier = Modifier.clickable {
                     clipboardManager.setText(AnnotatedString(chargePoint.identity))
                 }
             )
+            Text("Latency: ${chargePoint.averageLatencyMillis}ms")
             Text("Status: ${chargePoint.status}")
             Text("Status At: ${chargePoint.statusAt.toReadable()}")
             Text("Firmware: ${chargePoint.firmware}")


### PR DESCRIPTION
It's now possible to get a rough overview of what the connection latency is for a given charge point

<img width="1268" alt="Screenshot 2024-10-02 at 12 26 49 PM" src="https://github.com/user-attachments/assets/8a3d2c72-e425-4240-a906-993aa807d6ef">
