### PR TITLE
fix: Corrected `sentry.dsn=null` (the string 'null') giving warning o…

### DIFF
--- a/v16/build.gradle.kts
+++ b/v16/build.gradle.kts
@@ -119,8 +119,8 @@ compose.desktop {
             packageVersion = "$version"
 
             // JVM arguments, pass build-time properties here
-            jvmArgs += listOf(
-                "-Dsentry.dsn=${System.getenv("SENTRY_DSN") ?: null}"
+            jvmArgs += listOfNotNull(
+                System.getenv("SENTRY_DSN")?.let { "-Dsentry.dsn=$it" }
             )
 
             macOS {


### PR DESCRIPTION
…n startup if running the gradle `run` target

The original gradle file made this fail on startup because the string 'null' would be passed in

![image](https://github.com/user-attachments/assets/7057e1ac-5341-4e13-af78-95f85fdb5860)
