### PR TITLE
fix: Occasionally the client crashes when scrolling of the log fails …

### DIFF
--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/view/components/ChargePointLogView.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/view/components/ChargePointLogView.kt
@@ -24,6 +24,7 @@ import com.monta.ocpp.emulator.theme.AppThemeViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.lang.IndexOutOfBoundsException
 
 @Composable
 fun chargePointLogComponent(
@@ -61,7 +62,9 @@ fun chargePointLogComponent(
                             logItems.size != 0 &&
                             navigationViewModel.windowHasFocus
                         ) {
-                            lazyListState.scrollToItem(logItems.size - 1)
+                            try {
+                                lazyListState.scrollToItem(logItems.size - 1)
+                            } catch (ignore: IndexOutOfBoundsException) { /* ignore - this happens sometimes */ }
                         }
                     }
                 }


### PR DESCRIPTION
…in the GUI - this catches this ignorable exception

fixes [OCPP-EMULATOR-BY](https://monta-app.sentry.io/issues/5959585539/)