### PR TITLE
chore: Upgrade OCPP library

### DIFF
--- a/v16/build.gradle.kts
+++ b/v16/build.gradle.kts
@@ -30,8 +30,8 @@ kotlin {
                 implementation(compose.desktop.currentOs)
 
                 // OCPP Libs
-                implementation("com.github.monta-app.library-ocpp:core:1.0.3")
-                implementation("com.github.monta-app.library-ocpp:v16:1.0.3")
+                implementation("com.github.monta-app.library-ocpp:ocpp-core:1.0.4")
+                implementation("com.github.monta-app.library-ocpp:ocpp-v16:1.0.4")
 
                 // Coroutines
                 implementation(project.dependencies.platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.9.0"))

--- a/v201/build.gradle.kts
+++ b/v201/build.gradle.kts
@@ -31,8 +31,8 @@ kotlin {
                 implementation(compose.material3)
 
                 // OCPP Libs
-                implementation("com.github.monta-app.library-ocpp:core:1.0.3")
-                implementation("com.github.monta-app.library-ocpp:v201:1.0.3")
+                implementation("com.github.monta-app.library-ocpp:ocpp-core:1.0.4")
+                implementation("com.github.monta-app.library-ocpp:ocpp-v201:1.0.4")
 
                 // Coroutines
                 implementation(project.dependencies.platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.9.0"))


### PR DESCRIPTION
See library release notes -> [v1.0.4](https://github.com/monta-app/library-ocpp/releases/tag/v1.0.4)