### PR TITLE
chore: Change the `kotlinlogging` to handle the relocate of the upstream lib

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -54,7 +54,7 @@ kotlin {
 
                 // Logging
                 implementation("ch.qos.logback:logback-classic:1.5.18")
-                implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+                implementation("io.github.oshai:kotlin-logging-jvm:7.0.6")
 
                 // Sentry (Crash reporting)
                 implementation(project.dependencies.platform("io.sentry:sentry-bom:8.5.0"))

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/WindowExtensions.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/WindowExtensions.kt
@@ -11,8 +11,8 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.window.WindowExceptionHandlerFactory
 import androidx.compose.ui.window.WindowState
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.sentry.Sentry
-import mu.KotlinLogging
 import java.awt.event.WindowEvent
 import java.awt.event.WindowFocusListener
 

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/util/CoroutineExtensions.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/util/CoroutineExtensions.kt
@@ -1,11 +1,11 @@
 package com.monta.ocpp.emulator.common.util
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
 

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/database/DatabaseInitiator.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/database/DatabaseInitiator.kt
@@ -3,7 +3,7 @@ package com.monta.ocpp.emulator.database
 import com.monta.ocpp.emulator.common.util.appRoot
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.exposed.sql.Database
 import java.io.File
 import javax.sql.DataSource

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/logger/ChargePointLogger.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/logger/ChargePointLogger.kt
@@ -1,9 +1,9 @@
 package com.monta.ocpp.emulator.logger
 
 import com.monta.ocpp.emulator.common.util.PrettyJsonFormatter
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import mu.KotlinLogging
 import java.time.OffsetDateTime
 import java.util.concurrent.ConcurrentHashMap
 

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/update/AppUpdateService.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/update/AppUpdateService.kt
@@ -10,6 +10,7 @@ import com.monta.ocpp.emulator.update.model.GithubAsset
 import com.monta.ocpp.emulator.update.model.GithubRelease
 import com.monta.ocpp.emulator.update.model.OS
 import com.monta.ocpp.emulator.update.model.UpdateState
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
@@ -24,7 +25,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import mu.KotlinLogging
 import net.swiftzer.semver.SemVer
 import org.koin.core.annotation.Singleton
 import java.awt.Desktop

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/vehicle/view/VehicleLogger.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/vehicle/view/VehicleLogger.kt
@@ -1,9 +1,9 @@
 package com.monta.ocpp.emulator.vehicle.view
 
 import com.monta.ocpp.emulator.common.util.PrettyJsonFormatter
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import mu.KotlinLogging
 import org.koin.core.annotation.Singleton
 import java.time.OffsetDateTime
 

--- a/v16/build.gradle.kts
+++ b/v16/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
 
                 // Logging
                 implementation("ch.qos.logback:logback-classic:1.5.18")
-                implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+                implementation("io.github.oshai:kotlin-logging-jvm:7.0.6")
 
                 // Sentry (Crash reporting)
                 implementation(project.dependencies.platform("io.sentry:sentry-bom:8.5.0"))

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/App.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/App.kt
@@ -6,15 +6,17 @@ import com.monta.ocpp.emulator.interceptor.view.EditMessageWindow
 import com.monta.ocpp.emulator.interceptor.view.SendMessageWindow
 import com.monta.ocpp.emulator.user.AnalyticsHelper
 import com.monta.ocpp.emulator.v16.connection.ConnectionManager
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.runBlocking
-import mu.KotlinLogging
 import org.koin.core.logger.Level
 import org.koin.ksp.generated.module
 import org.koin.mp.KoinPlatform
+import java.util.TimeZone
 
 private val logger = KotlinLogging.logger {}
 
 fun main() {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
     try {
         KoinPlatform.startKoin(
             listOf(

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/DatabaseExtensions.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/DatabaseExtensions.kt
@@ -1,11 +1,11 @@
 package com.monta.ocpp.emulator.common
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
-import mu.KotlinLogging
 import org.jetbrains.exposed.dao.EntityChange
 import org.jetbrains.exposed.dao.EntityHook
 import org.jetbrains.exposed.dao.LongEntity

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/DatabaseService.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/DatabaseService.kt
@@ -7,7 +7,7 @@ import com.monta.ocpp.emulator.chargepointtransaction.entity.ChargePointTransact
 import com.monta.ocpp.emulator.configuration.AppConfigTable
 import com.monta.ocpp.emulator.database.DatabaseInitiator
 import com.monta.ocpp.emulator.v16.data.entity.TxDefault
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.koin.core.annotation.Singleton

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/ChargePointConnectorExtensions.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/ChargePointConnectorExtensions.kt
@@ -10,8 +10,8 @@ import com.monta.ocpp.emulator.chargepointconnector.model.CarState
 import com.monta.ocpp.emulator.chargepointtransaction.service.ChargePointTransactionService
 import com.monta.ocpp.emulator.common.util.injectAnywhere
 import com.monta.ocpp.emulator.logger.GlobalLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.delay
-import mu.KotlinLogging
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.Instant
 

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/ChargePointManager.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/ChargePointManager.kt
@@ -21,8 +21,8 @@ import com.monta.ocpp.emulator.common.idValue
 import com.monta.ocpp.emulator.common.util.injectAnywhere
 import com.monta.ocpp.emulator.logger.GlobalLogger
 import com.monta.ocpp.emulator.v16.connection.ConnectionManager
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.delay
-import mu.KotlinLogging
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.koin.core.annotation.Singleton
 import java.time.Instant

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/OcppClientExtensions.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/OcppClientExtensions.kt
@@ -17,7 +17,7 @@ import com.monta.ocpp.emulator.chargepointtransaction.entity.ChargePointTransact
 import com.monta.ocpp.emulator.common.idValue
 import com.monta.ocpp.emulator.common.util.injectAnywhere
 import com.monta.ocpp.emulator.eichrecht.EichrechtSignatureService
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.Instant
 import java.time.ZonedDateTime

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/SchedulerService.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/SchedulerService.kt
@@ -11,10 +11,10 @@ import com.monta.ocpp.emulator.common.util.injectAnywhere
 import com.monta.ocpp.emulator.common.util.launchThread
 import com.monta.ocpp.emulator.logger.GlobalLogger
 import com.monta.ocpp.emulator.v16.util.MeterValuesGenerator
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.yield
-import mu.KotlinLogging
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.koin.core.annotation.Factory
 import java.time.Duration

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/connection/ChargePointConnection.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/connection/ChargePointConnection.kt
@@ -10,6 +10,7 @@ import com.monta.ocpp.emulator.common.util.MontaSerialization
 import com.monta.ocpp.emulator.common.util.injectAnywhere
 import com.monta.ocpp.emulator.interceptor.MessageInterceptor
 import com.monta.ocpp.emulator.logger.GlobalLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.websocket.*
@@ -17,7 +18,6 @@ import io.ktor.client.request.*
 import io.ktor.util.collections.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.delay
-import mu.KotlinLogging
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/connection/ConnectionManager.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/connection/ConnectionManager.kt
@@ -4,9 +4,9 @@ import com.monta.ocpp.emulator.chargepoint.repository.ChargePointRepository
 import com.monta.ocpp.emulator.common.util.launchThread
 import com.monta.ocpp.emulator.interceptor.MessageInterceptor
 import com.monta.ocpp.emulator.v16.SchedulerService
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.joinAll
-import mu.KotlinLogging
 import org.koin.core.annotation.Singleton
 
 @Singleton

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/profile/FirmwareManagementHandler.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/profile/FirmwareManagementHandler.kt
@@ -11,8 +11,8 @@ import com.monta.ocpp.emulator.chargepoint.service.ChargePointService
 import com.monta.ocpp.emulator.common.util.injectAnywhere
 import com.monta.ocpp.emulator.common.util.launchThread
 import com.monta.ocpp.emulator.v16.ChargePointManager
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.*
-import mu.KotlinLogging
 import org.koin.core.annotation.Singleton
 
 @Singleton

--- a/v201/build.gradle.kts
+++ b/v201/build.gradle.kts
@@ -61,7 +61,7 @@ kotlin {
 
                 // Logging
                 implementation("ch.qos.logback:logback-classic:1.5.18")
-                implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+                implementation("io.github.oshai:kotlin-logging-jvm:7.0.6")
 
                 // Sentry (Crash reporting)
                 implementation(project.dependencies.platform("io.sentry:sentry-bom:8.5.0"))

--- a/v201/src/jvmMain/kotlin/com/monta/ocpp/emulator/v201/App.kt
+++ b/v201/src/jvmMain/kotlin/com/monta/ocpp/emulator/v201/App.kt
@@ -3,14 +3,16 @@ package com.monta.ocpp.emulator.v201
 import androidx.compose.ui.window.application
 import com.monta.ocpp.emulator.CommonKoinModule
 import com.monta.ocpp.emulator.v201.view.main.MainWindow
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.core.logger.Level
 import org.koin.ksp.generated.module
 import org.koin.mp.KoinPlatform
+import java.util.TimeZone
 
 private val logger = KotlinLogging.logger {}
 
 fun main() {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
     try {
         KoinPlatform.startKoin(
             listOf(

--- a/v201/src/jvmMain/kotlin/com/monta/ocpp/emulator/v201/features/database/DatabaseService.kt
+++ b/v201/src/jvmMain/kotlin/com/monta/ocpp/emulator/v201/features/database/DatabaseService.kt
@@ -2,7 +2,7 @@ package com.monta.ocpp.emulator.v201.features.database
 
 import com.monta.ocpp.emulator.configuration.AppConfigTable
 import com.monta.ocpp.emulator.database.DatabaseInitiator
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.koin.core.annotation.Singleton


### PR DESCRIPTION
The kotlin logging library was relocated from `io.github.microutils` to `io.github.oshai` when going from v3 to v5, so we were several versions behind - details in [readme -> Version 5 vs. previous versions](https://github.com/oshai/kotlin-logging?tab=readme-ov-file#version-5-vs-previous-versions)

* `io.github.microutils:kotlin-logging-jvm:3.0.5` -> `io.github.oshai:kotlin-logging-jvm:7.0.6`

* minor - change the app to run in UTC, ensuring that the database times are correct