### PR TITLE
chore: update release notification slack channel

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -81,4 +81,5 @@ jobs:
           version-mode: "SemVer"
           output: "slack"
           slack-token: ${{ secrets.SLACK_APP_TOKEN }}
-          slack-channels: "#releases,#ocpp-emulator"
+          # Slack channel: C02PDBL6GAU = #info-releases
+          slack-channels: "C02PDBL6GAU,#ocpp-emulator"


### PR DESCRIPTION
## Summary
Update release notification slack channel reference from channel name (#releases/#info-releases) to channel ID (C02PDBL6GAU) for better reliability and consistency.

## Changes
- Replace `#releases` or `#info-releases` with channel ID `C02PDBL6GAU`
- Add comment above slack-channels parameter for clarity
- Preserve all other channel references

## Why
Channel IDs are more reliable than channel names because:
- Channel names can change, IDs are permanent
- Avoids potential issues with special characters
- Consistent with Slack API best practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)