### PR TITLE
chore: enable SonarQube (self-hosted) [NOJIRA]

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,14 +7,16 @@ jobs:
     name: Test
     uses: monta-app/github-workflows/.github/workflows/pull-request-kotlin.yml@main
     with:
-      skip-sonar: true
       architecture: "arm64"
-      gradle-module: "common"
       kover-report-path: "common/build/reports/kover/report.xml"
     secrets:
       GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
       GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+      # Self-hosted SonarQube lives behind the Monta VPN, so the runner joins the
+      # tailnet before the scan. (The reusable workflow guards the Tailscale step on
+      # this secret being set.)
+      TAILSCALE_AUTHKEY: ${{ secrets.TAILSCALE_AUTHKEY }}
   static-code-analysis:
     name: Static Code Analysis
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kover) apply false
+    alias(libs.plugins.sonarqube)
 }
 
 allprojects {
@@ -14,5 +15,20 @@ allprojects {
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
         maven("https://jitpack.io")
+    }
+}
+
+sonar {
+    properties {
+        property("sonar.projectKey", "monta-app_ocpp-emulator")
+        property("sonar.projectName", "ocpp-emulator")
+        property("sonar.host.url", "https://sonarqube.vpn.internal.monta.app/")
+        // Only the `common` module has tests/coverage (kover is applied there).
+        property("sonar.coverage.jacoco.xmlReportPaths", "common/build/reports/kover/report.xml")
+        // Kotlin Multiplatform build (jvm() target only). The Sonar Gradle plugin does
+        // not reliably auto-detect KMP source sets, so point it at the JVM source roots
+        // explicitly. v16 is the Compose desktop app shell.
+        property("sonar.sources", "common/src/jvmMain/kotlin,v16/src/jvmMain/kotlin")
+        property("sonar.tests", "common/src/jvmTest/kotlin")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ compose = "1.10.2"
 ktlint = "14.2.0"
 ksp = "2.3.6"
 kover = "0.9.7"
+sonarqube = "7.3.1.8318"
 junit = "6.0.3"
 
 kotlinx-coroutines = "1.10.2"
@@ -102,3 +103,4 @@ kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }


### PR DESCRIPTION
## What?

Enables SonarQube analysis for `ocpp-emulator`. This was the one Kotlin repo running with **`skip-sonar: true`** in its caller workflow, and it had **no SonarQube config at all** — so this adds the setup from scratch, pointed straight at the self-hosted **SonarQube** (`https://sonarqube.vpn.internal.monta.app`), not SonarCloud.

## Changes

- **`gradle/libs.versions.toml`** — add the `org.sonarqube` plugin at `7.3.1.8318` (the version the rest of the Kotlin fleet uses).
- **`build.gradle.kts`** — apply `org.sonarqube` at the **root** project and add a `sonar { }` block:
  - `sonar.projectKey=monta-app_ocpp-emulator`, `sonar.projectName=ocpp-emulator`
  - `sonar.host.url` → self-hosted SonarQube
  - coverage from the `common` module's Kover XML (`common/build/reports/kover/report.xml`)
  - **explicit KMP JVM source roots** (`sonar.sources` / `sonar.tests`) — this is a Kotlin Multiplatform build (`jvm()` only) and the Sonar Gradle plugin doesn't reliably auto-detect KMP source sets.
- **`.github/workflows/pull_request.yml`**:
  - removed `skip-sonar: true`
  - removed `gradle-module: "common"` so the root-level `sonar` task is invoked (the `org.sonarqube` plugin only registers `sonar` on the root project; with a module prefix it would look for a non-existent `:common:sonar`)
  - `SONAR_TOKEN` source secret → `secrets.SONARQUBE_TOKEN`
  - pass `TAILSCALE_AUTHKEY` (self-hosted SonarQube is behind the Monta VPN; the reusable workflow guards the Tailscale step on this secret)

The SonarQube project `monta-app_ocpp-emulator` is pre-created and bound to this repo, so the first analysis posts PR decoration.

## Heads-up for review (draft until CI confirms)

Two things to watch on the first CI run, both consequences of dropping `gradle-module`:

1. **`ktlintCheck` now runs on `v16` too** (previously only `common` was checked). If `v16` has lint drift it'll surface here — easy to fix, just flagging it isn't a Sonar issue.
2. **KMP source/coverage indexing** — if Sonar reports 0 indexed files or misses coverage, the explicit `sonar.sources`/`xmlReportPaths` may need a tweak. Keeping it draft until the dashboard shows real LOC + coverage.

## Context

Part of the org-wide migration to self-hosted SonarQube, and the follow-up "repos that should newly get Sonar" pass discussed in #project-migrate-to-sonarqube. Reference pattern: https://github.com/monta-app/server/pull/23360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
