### PR TITLE
fix: remote stop transaction lookup

### DIFF
--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepointtransaction/repository/ChargePointTransactionRepository.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepointtransaction/repository/ChargePointTransactionRepository.kt
@@ -2,6 +2,7 @@ package com.monta.ocpp.emulator.chargepointtransaction.repository
 
 import com.monta.ocpp.emulator.chargepointtransaction.entity.ChargePointTransaction
 import com.monta.ocpp.emulator.chargepointtransaction.entity.ChargePointTransactionDAO
+import org.jetbrains.exposed.sql.and
 import javax.inject.Singleton
 
 @Singleton
@@ -11,6 +12,17 @@ class ChargePointTransactionRepository {
     ): ChargePointTransactionDAO? {
         return ChargePointTransactionDAO.find {
             ChargePointTransaction.externalId eq externalId
+        }.firstOrNull()
+    }
+
+    fun getActiveByExternalIdAndChargePointId(
+        externalId: Int,
+        chargePointId: Long,
+    ): ChargePointTransactionDAO? {
+        return ChargePointTransactionDAO.find {
+            (ChargePointTransaction.externalId eq externalId) and
+                (ChargePointTransaction.chargePointId eq chargePointId) and
+                (ChargePointTransaction.endTime eq null)
         }.firstOrNull()
     }
 }

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepointtransaction/service/ChargePointTransactionService.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepointtransaction/service/ChargePointTransactionService.kt
@@ -36,6 +36,18 @@ class ChargePointTransactionService(
         }
     }
 
+    fun getActiveByExternalIdAndChargePoint(
+        externalId: Int,
+        chargePoint: ChargePointDAO,
+    ): ChargePointTransactionDAO? {
+        return transaction {
+            chargePointTransactionRepository.getActiveByExternalIdAndChargePointId(
+                externalId = externalId,
+                chargePointId = chargePoint.id.value,
+            )
+        }
+    }
+
     fun update(
         externalId: Int,
         block: ChargePointTransactionDAO.() -> Unit,

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/profile/CoreClientHandler.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/profile/CoreClientHandler.kt
@@ -222,26 +222,13 @@ class CoreClientHandler : CoreClientProfile.Listener {
     ): RemoteStopTransactionConfirmation {
         val chargePoint = chargePointService.getByIdentity(ocppSessionInfo.identity)
 
-        val chargePointTransaction = chargePointTransactionService.getByExternalId(
+        val chargePointTransaction = chargePointTransactionService.getActiveByExternalIdAndChargePoint(
             externalId = request.transactionId,
+            chargePoint = chargePoint,
         )
 
         if (chargePointTransaction == null) {
-            GlobalLogger.error(chargePoint, "transaction not found for externalId ${request.transactionId}")
-            return RemoteStopTransactionConfirmation(
-                status = RemoteStartStopStatus.Rejected,
-            )
-        }
-
-        if (!chargePointTransaction.isOwner(chargePoint)) {
-            GlobalLogger.error(chargePointTransaction, "charge point doesn't own this transaction")
-            return RemoteStopTransactionConfirmation(
-                status = RemoteStartStopStatus.Rejected,
-            )
-        }
-
-        if (!chargePointTransaction.canStop()) {
-            GlobalLogger.error(chargePointTransaction, "charge already ended, rejecting")
+            GlobalLogger.error(chargePoint, "active transaction not found for externalId ${request.transactionId}")
             return RemoteStopTransactionConfirmation(
                 status = RemoteStartStopStatus.Rejected,
             )


### PR DESCRIPTION
This pull request adds a new method to retrieve active transactions by both `externalId` and `chargePointId`, and updates the logic for handling remote stop transaction requests to use this new method. The main goal is to ensure that only active transactions belonging to the correct charge point are considered, simplifying and strengthening the transaction validation process.

**Repository and service enhancements:**

* Added `getActiveByExternalIdAndChargePointId` method to `ChargePointTransactionRepository`, allowing retrieval of an active (not ended) transaction matching both `externalId` and `chargePointId`.
* Added `getActiveByExternalIdAndChargePoint` method to `ChargePointTransactionService` to provide a service-layer wrapper for the new repository method.

**Remote stop transaction logic update:**

* Updated `CoreClientHandler` to use the new `getActiveByExternalIdAndChargePoint` method when handling remote stop transaction requests, and removed redundant ownership and status checks, relying on the new method to ensure correct transaction selection.

**Dependency update:**

* Added import for `org.jetbrains.exposed.sql.and` to support combined query conditions in the repository.