### PR TITLE
fix: resolve all compiler and build deprecation warnings

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -22,7 +22,10 @@ kotlin {
             implementation(compose.desktop.currentOs)
 
             // Material Icons
-            implementation(compose.materialIconsExtended)
+            implementation(libs.compose.material.icons.extended)
+
+            // Compose resources (classpath SVG loading)
+            implementation(libs.compose.components.resources)
 
             // Coroutines
             implementation(project.dependencies.platform(libs.kotlinx.coroutines.bom))

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/FormInput.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/FormInput.kt
@@ -1,6 +1,5 @@
 package com.monta.ocpp.emulator.common.components
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/MontaIcon.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/MontaIcon.kt
@@ -7,7 +7,6 @@ import androidx.compose.material.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -21,7 +20,7 @@ fun MontaIcon(
     if (tooltipText != null) {
         TextTooltip(tooltipText) {
             Icon(
-                painter = painterResource("icons/$iconName.svg"),
+                painter = svgPainterResource("icons/$iconName.svg"),
                 contentDescription = contentDescription,
                 modifier = modifier.size(16.dp),
                 tint = tint,
@@ -29,7 +28,7 @@ fun MontaIcon(
         }
     } else {
         Icon(
-            painter = painterResource("icons/$iconName.svg"),
+            painter = svgPainterResource("icons/$iconName.svg"),
             contentDescription = contentDescription,
             modifier = modifier.size(16.dp),
             tint = tint,
@@ -47,9 +46,9 @@ fun MontaStateIcon(
 ) {
     Icon(
         painter = if (state) {
-            painterResource("icons/$onState.svg")
+            svgPainterResource("icons/$onState.svg")
         } else {
-            painterResource("icons/$offState.svg")
+            svgPainterResource("icons/$offState.svg")
         },
         contentDescription = "",
         modifier = modifier.size(24.dp),

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/MontaIcons.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/MontaIcons.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 
@@ -57,7 +56,7 @@ fun RfidButton(
         contentPadding = PaddingValues(0.dp),
     ) {
         Icon(
-            painter = painterResource("icons/rfid.svg"),
+            painter = svgPainterResource("icons/rfid.svg"),
             contentDescription = "Authorize",
             modifier = Modifier
                 .padding(0.dp)

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/PasswordField.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/PasswordField.kt
@@ -8,7 +8,6 @@ import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
@@ -44,9 +43,9 @@ fun ColumnScope.PasswordField(
             ) {
                 Icon(
                     painter = if (passwordVisibility) {
-                        painterResource("icons/visibility_off.svg")
+                        svgPainterResource("icons/visibility_off.svg")
                     } else {
-                        painterResource("icons/visibility.svg")
+                        svgPainterResource("icons/visibility.svg")
                     },
                     contentDescription = "",
                     modifier = Modifier.size(24.dp),

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/Spinner.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/Spinner.kt
@@ -1,6 +1,5 @@
 package com.monta.ocpp.emulator.common.components
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -23,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/SvgPainter.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/components/SvgPainter.kt
@@ -1,0 +1,32 @@
+package com.monta.ocpp.emulator.common.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalDensity
+import org.jetbrains.compose.resources.decodeToSvgPainter
+
+/**
+ * Loads an SVG [Painter] from the application classpath, replacing the
+ * deprecated `androidx.compose.ui.res.painterResource(String)`.
+ */
+@Composable
+fun svgPainterResource(
+    resourcePath: String,
+): Painter {
+    val density = LocalDensity.current
+    return remember(resourcePath, density) {
+        SvgResources.readBytes(resourcePath).decodeToSvgPainter(density)
+    }
+}
+
+private object SvgResources {
+    fun readBytes(
+        resourcePath: String,
+    ): ByteArray {
+        val stream = requireNotNull(javaClass.classLoader.getResourceAsStream(resourcePath)) {
+            "Resource not found on classpath: $resourcePath"
+        }
+        return stream.use { it.readBytes() }
+    }
+}

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/util/MontaSerialization.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/util/MontaSerialization.kt
@@ -60,7 +60,7 @@ object MontaSerialization {
         objectMapper.registerKotlinModule()
         objectMapper.registerModule(JavaTimeModule())
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        objectMapper.setSerializationInclusion(
+        objectMapper.setDefaultPropertyInclusion(
             if (serializeNulls) {
                 JsonInclude.Include.ALWAYS
             } else {

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/util/PrettyJsonFormatter.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/util/PrettyJsonFormatter.kt
@@ -43,7 +43,7 @@ object PrettyJsonFormatter {
         registerKotlinModule()
         registerModule(JavaTimeModule())
         configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        setSerializationInclusion(jsonInclude)
+        setDefaultPropertyInclusion(jsonInclude)
         disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         findAndRegisterModules()
         return this

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/util/PrettyYamlFormatter.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/util/PrettyYamlFormatter.kt
@@ -15,7 +15,7 @@ object PrettyYamlFormatter {
         .registerKotlinModule()
         .registerModule(JavaTimeModule())
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        .setSerializationInclusion(JsonInclude.Include.ALWAYS)
+        .setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS)
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         .findAndRegisterModules()
 

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/eichrecht/OCMFPayload.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/eichrecht/OCMFPayload.kt
@@ -13,22 +13,22 @@ data class OCMFPayload(
      * i.e. 0.4 corresponds to major 0 and minor 4.
      * The revision (third digit) is not transmitted, since this does not change anything in the format itself.
      */
-    @JsonProperty("FV")
+    @param:JsonProperty("FV")
     val formatVersion: String,
     /**
      * Gateway Identification: Identifier of the manufacturer for the system which has generated the present data (manufacturer, model, variant, etc.).
      */
-    @JsonProperty("GI")
+    @param:JsonProperty("GI")
     val gatewayIdentification: String? = null,
     /**
      * Gateway Serial: Serial number of the above mentioned system. This field is conditionally mandatory.
      */
-    @JsonProperty("GS")
+    @param:JsonProperty("GS")
     val gatewaySerial: String? = null,
     /**
      * Gateway Version: Version designation of the manufacturer for the software of the above mentioned system. This field is optional.
      */
-    @JsonProperty("GV")
+    @param:JsonProperty("GV")
     val gatewayVersion: String? = null,
 
     /**
@@ -42,7 +42,7 @@ data class OCMFPayload(
      *
      * The respective pagination counter is incremented after each use for a record.
      */
-    @JsonProperty("PG")
+    @param:JsonProperty("PG")
     val pagination: String,
 
     /*
@@ -52,22 +52,22 @@ data class OCMFPayload(
     /**
      * Meter Vendor: Manufacturer identification of the meter, name of the manufacturer
      */
-    @JsonProperty("MV")
+    @param:JsonProperty("MV")
     val meterVendor: String? = null,
     /**
      * Meter Model: Model identification of the meter
      */
-    @JsonProperty("MM")
+    @param:JsonProperty("MM")
     val meterModel: String? = null,
     /**
      * Meter Serial: Serial number of the meter
      */
-    @JsonProperty("MS")
+    @param:JsonProperty("MS")
     val meterSerial: String,
     /**
      * Meter Firmware: Firmware version of the meter
      */
-    @JsonProperty("MF")
+    @param:JsonProperty("MF")
     val meterFirmware: String? = null,
 
     /*
@@ -79,34 +79,34 @@ data class OCMFPayload(
      * - true: user successfully assigned
      * - false: user not assigned
      */
-    @JsonProperty("IS")
+    @param:JsonProperty("IS")
     val identificationStatus: Boolean,
     /**
      * Identification Level: Encoded overall status of the user assignment, represented by an identifier from table 11.
      */
-    @JsonProperty("IL")
+    @param:JsonProperty("IL")
     val identificationLevel: String? = null,
     /**
      * Identification Flags: Detailed statements about the user assignment, represented by one or more identifiers from table 13 to table 16.
      * The identifiers are always noted as string elements in an array. Also one or no element must be noted as an array.
      */
-    @JsonProperty("IF")
+    @param:JsonProperty("IF")
     val identificationFlags: List<String>? = null,
     /**
      * Identification Type: Type of identification data, identifier see table 17.
      */
-    @JsonProperty("IT")
+    @param:JsonProperty("IT")
     val identificationType: String,
     /**
      * Identification Data: The actual identification data according to the type from table 17, e.g. a hex-coded UID according to ISO 14443.
      */
-    @JsonProperty("ID")
+    @param:JsonProperty("ID")
     val identificationData: String? = null,
     /**
      * Tariff Text: A textual description used to identify a unique tariff.
      * This field is intended for the tariff designation in "Direct Payment" use case.
      */
-    @JsonProperty("TT")
+    @param:JsonProperty("TT")
     val tariffText: String? = null,
 
     /*
@@ -116,17 +116,17 @@ data class OCMFPayload(
     /**
      * Charge Point Identification Type: Type of the specification for the identification of the charge point, identifier see table 18.
      */
-    @JsonProperty("CT")
+    @param:JsonProperty("CT")
     val chargePointIdentificationType: String? = null,
     /**
      * Charge Point Identification: Identification information for the charge point.
      */
-    @JsonProperty("CI")
+    @param:JsonProperty("CI")
     val chargePointIdentification: String? = null,
 
     /**
      * The list of readings
      */
-    @JsonProperty("RD")
+    @param:JsonProperty("RD")
     val readings: List<OCMFReading>,
 )

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/eichrecht/OCMFReading.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/eichrecht/OCMFReading.kt
@@ -21,7 +21,7 @@ data class OCMFReading(
      * The synchronization state consists of a capital letter as identifier.
      * This is added to the time, separated by a space. Available states see table 19.
      */
-    @JsonProperty("TM")
+    @param:JsonProperty("TM")
     val time: String,
 
     /**
@@ -37,7 +37,7 @@ data class OCMFReading(
      * - S – Suspended = Transaction active, but currently not charging (can be used optionally)
      * - T – Tariff change <br> This field is missing if there is no transaction reference (Fiscal Metering).
      */
-    @JsonProperty("TX")
+    @param:JsonProperty("TX")
     val transaction: Char? = null,
 
     /**
@@ -48,19 +48,19 @@ data class OCMFReading(
      * since this would change the representation of the physical quantity and thus potentially the number of valid digits.
      * According to the application rule, it is recommended to represent the measured value with two decimal places of accuracy, if it is kWh.
      */
-    @JsonProperty("RV")
+    @param:JsonProperty("RV")
     val value: Double,
 
     /**
      * Reading Identification: Identifier, which quantity was read, according to OBIS code.
      */
-    @JsonProperty("RI")
+    @param:JsonProperty("RI")
     val identification: String? = null,
 
     /**
      * Reading Unit: Unit of reading, e.g. kWh, according to table 20: Predefined Units.
      */
-    @JsonProperty("RU")
+    @param:JsonProperty("RU")
     val unit: String,
 
     /**
@@ -68,7 +68,7 @@ data class OCMFReading(
      * Predefined Current Types.
      * This field is optional. No default value is defined.
      */
-    @JsonProperty("RT")
+    @param:JsonProperty("RT")
     val currenType: String? = null,
 
     /**
@@ -76,7 +76,7 @@ data class OCMFReading(
      * The value reported here represents cumulated loss withdrawned from measurement when computing loss compensation on RV.
      * CL must be reset at TX=B. CL is given in the same unit as RV which is specified in RU.
      */
-    @JsonProperty("CL")
+    @param:JsonProperty("CL")
     val cumulatedLoss: Number? = null,
 
     /**
@@ -85,13 +85,13 @@ data class OCMFReading(
      * - E – Energy
      * - t – Time
      */
-    @JsonProperty("EF")
+    @param:JsonProperty("EF")
     val errorFlags: String? = null,
 
     /**
      * Status: State of the meter at the time of reading. Noted as abbreviation according to table 10.
      */
-    @JsonProperty("ST")
+    @param:JsonProperty("ST")
     val status: Char,
 ) {
     companion object {

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/eichrecht/OCMFSignature.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/eichrecht/OCMFSignature.kt
@@ -8,7 +8,7 @@ data class OCMFSignature(
      * This includes the signature algorithm, its parameters, and the hash algorithm that will be applied to the data to be signed.
      * This specification is optional. If it is omitted, the default value is effective.
      */
-    @JsonProperty("SA")
+    @param:JsonProperty("SA")
     val signatureAlgorithm: String?,
 
     /**
@@ -18,7 +18,7 @@ data class OCMFSignature(
      * - hex – The signature data is represented in the JSON string in hexadecimal encoding (default)
      * - base64 – The signature data is base64 encoded in the JSON string.
      */
-    @JsonProperty("SE")
+    @param:JsonProperty("SE")
     val signatureEncoding: String? = null,
 
     /**
@@ -27,12 +27,12 @@ data class OCMFSignature(
      * The following values are possible:
      * - `application/x-der` – DER encoded ASN.1 structure (default)
      */
-    @JsonProperty("SM")
+    @param:JsonProperty("SM")
     val signatureMimeType: String? = null,
 
     /**
      * Signature Data: The actual signature data according to the format specification above.
      */
-    @JsonProperty("SD")
+    @param:JsonProperty("SD")
     val signatureData: String,
 )

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/update/AppUpdateService.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/update/AppUpdateService.kt
@@ -57,7 +57,7 @@ class AppUpdateService {
                 registerKotlinModule()
                 registerModule(JavaTimeModule())
                 configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
                 disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 findAndRegisterModules()
             }

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/update/model/GithubAsset.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/update/model/GithubAsset.kt
@@ -3,18 +3,18 @@ package com.monta.ocpp.emulator.update.model
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class GithubAsset(
-    @JsonProperty("id")
+    @param:JsonProperty("id")
     val id: Int, // 91875607
-    @JsonProperty("node_id")
+    @param:JsonProperty("node_id")
     val nodeId: String, // RA_kwDOIrJZFs4FeekX
-    @JsonProperty("name")
+    @param:JsonProperty("name")
     val name: String, // mac-OcppEmulator-1.1.4.dmg
-    @JsonProperty("label")
+    @param:JsonProperty("label")
     val label: String?,
-    @JsonProperty("content_type")
+    @param:JsonProperty("content_type")
     val contentType: String, // binary/octet-stream
-    @JsonProperty("state")
+    @param:JsonProperty("state")
     val state: String, // uploaded
-    @JsonProperty("size")
+    @param:JsonProperty("size")
     val size: Int, // 65635314)
 )

--- a/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/update/model/GithubRelease.kt
+++ b/common/src/jvmMain/kotlin/com/monta/ocpp/emulator/update/model/GithubRelease.kt
@@ -4,38 +4,38 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.OffsetDateTime
 
 data class GithubRelease(
-    @JsonProperty("url")
+    @param:JsonProperty("url")
     val url: String,
-    @JsonProperty("assets_url")
+    @param:JsonProperty("assets_url")
     val assetsUrl: String,
-    @JsonProperty("upload_url")
+    @param:JsonProperty("upload_url")
     val uploadUrl: String,
-    @JsonProperty("html_url")
+    @param:JsonProperty("html_url")
     val htmlUrl: String,
-    @JsonProperty("id")
+    @param:JsonProperty("id")
     val id: Int,
-    @JsonProperty("node_id")
+    @param:JsonProperty("node_id")
     val nodeId: String,
-    @JsonProperty("tag_name")
+    @param:JsonProperty("tag_name")
     val tagName: String,
-    @JsonProperty("target_commitish")
+    @param:JsonProperty("target_commitish")
     val targetCommitish: String,
-    @JsonProperty("name")
+    @param:JsonProperty("name")
     val name: String,
-    @JsonProperty("draft")
+    @param:JsonProperty("draft")
     val draft: Boolean,
-    @JsonProperty("prerelease")
+    @param:JsonProperty("prerelease")
     val prerelease: Boolean,
-    @JsonProperty("created_at")
+    @param:JsonProperty("created_at")
     val createdAt: OffsetDateTime,
-    @JsonProperty("published_at")
+    @param:JsonProperty("published_at")
     val publishedAt: OffsetDateTime,
-    @JsonProperty("assets")
+    @param:JsonProperty("assets")
     val assets: List<GithubAsset>,
-    @JsonProperty("tarball_url")
+    @param:JsonProperty("tarball_url")
     val tarballUrl: String,
-    @JsonProperty("zipball_url")
+    @param:JsonProperty("zipball_url")
     val zipballUrl: String,
-    @JsonProperty("body")
+    @param:JsonProperty("body")
     val body: String,
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,6 +76,12 @@ exposed-dao = { module = "org.jetbrains.exposed:exposed-dao" }
 exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc" }
 exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time" }
 
+# Compose (artifacts without a plugin accessor, or whose accessor is deprecated)
+compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose" }
+# The material-icons-extended artifact is frozen at 1.7.3 upstream; the compose plugin
+# accessor for it is deprecated and asks for an explicit pin like this one.
+compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version = "1.7.3" }
+
 # OCPP Libraries
 ocpp-core = { module = "com.github.monta-app.library-ocpp:ocpp-core", version.ref = "ocpp-library" }
 ocpp-v16 = { module = "com.github.monta-app.library-ocpp:ocpp-v16", version.ref = "ocpp-library" }

--- a/v16/build.gradle.kts
+++ b/v16/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
             implementation(compose.desktop.currentOs)
 
             // Material Icons
-            implementation(compose.materialIconsExtended)
+            implementation(libs.compose.material.icons.extended)
 
             // OCPP Libs
             implementation(libs.ocpp.core)

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/MainWindow.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/MainWindow.kt
@@ -1,9 +1,9 @@
 package com.monta.ocpp.emulator
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ApplicationScope

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/view/components/ChargePointComponent.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/view/components/ChargePointComponent.kt
@@ -15,9 +15,10 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.unit.dp
 import com.monta.library.ocpp.v16.core.ChargePointStatus
 import com.monta.ocpp.emulator.chargepoint.entity.ChargePointDAO
@@ -27,14 +28,16 @@ import com.monta.ocpp.emulator.common.components.getCardStyle
 import com.monta.ocpp.emulator.common.components.toReadable
 import com.monta.ocpp.emulator.v16.setStatus
 import kotlinx.coroutines.launch
+import java.awt.datatransfer.StringSelection
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun chargePointComponent(
     chargePoint: ChargePointDAO,
 ) {
     val coroutineScope = rememberCoroutineScope()
 
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
 
     Card(
         modifier = getCardStyle().fillMaxWidth(),
@@ -60,7 +63,9 @@ fun chargePointComponent(
             Text(
                 "Identity: ${chargePoint.identity}",
                 modifier = Modifier.clickable {
-                    clipboardManager.setText(AnnotatedString(chargePoint.identity))
+                    coroutineScope.launch {
+                        clipboard.setClipEntry(ClipEntry(StringSelection(chargePoint.identity)))
+                    }
                 },
             )
             Text("Latency: ${chargePoint.averageLatencyMillis} ms (${chargePoint.messageCount})")

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/DatabaseService.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/common/DatabaseService.kt
@@ -21,7 +21,7 @@ class DatabaseService {
     fun connect() {
         try {
             transaction {
-                SchemaUtils.createMissingTablesAndColumns(
+                val tables = arrayOf(
                     AppConfigTable,
                     ChargePointTable,
                     ChargePointConnectorTable,
@@ -29,6 +29,10 @@ class DatabaseService {
                     TxDefault,
                     PreviousMessagesTable,
                 )
+                SchemaUtils.create(*tables)
+                SchemaUtils.addMissingColumnsStatements(*tables).forEach { statement ->
+                    exec(statement)
+                }
             }
         } catch (exception: Exception) {
             logger.error(exception) { "database error" }

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/interceptor/view/InterceptorConfigComponent.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/interceptor/view/InterceptorConfigComponent.kt
@@ -1,6 +1,5 @@
 package com.monta.ocpp.emulator.interceptor.view
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight.Companion.W700
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import com.monta.library.ocpp.common.profile.Feature

--- a/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/interceptor/view/SendMessageWindow.kt
+++ b/v16/src/jvmMain/kotlin/com/monta/ocpp/emulator/interceptor/view/SendMessageWindow.kt
@@ -1,6 +1,7 @@
 package com.monta.ocpp.emulator.interceptor.view
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Card
@@ -217,16 +217,17 @@ fun ApplicationScope.SendMessageWindow() {
                                     border = BorderStroke(width = Dp.Hairline, color = Color.Gray),
                                 ) {
                                     Row(horizontalArrangement = Arrangement.SpaceBetween) {
-                                        ClickableText(
+                                        Text(
                                             text = AnnotatedString(previousMessage.message),
                                             style = TextStyle(
                                                 color = MaterialTheme.colors.contentColorFor(MaterialTheme.colors.surface),
                                                 fontFamily = FontFamily.Monospace,
                                             ),
-                                            modifier = Modifier.padding(12.dp).pointerHoverIcon(PointerIcon.Hand),
-                                            onClick = {
-                                                sendMessageWindowViewModel.messageYaml = previousMessage.message
-                                            },
+                                            modifier = Modifier.padding(12.dp)
+                                                .pointerHoverIcon(PointerIcon.Hand)
+                                                .clickable {
+                                                    sendMessageWindowViewModel.messageYaml = previousMessage.message
+                                                },
                                         )
                                         Button(
                                             modifier = Modifier.padding(12.dp).pointerHoverIcon(PointerIcon.Hand),


### PR DESCRIPTION
## Summary

Clears every deprecation warning in the build — `:common` and `:v16` now compile with zero warnings under Kotlin 2.4.10 / Compose 1.11.1. Split into six self-contained commits, one per deprecation group:

- **fix(build)** — the Compose 1.11 gradle plugin deprecated the `materialIconsExtended` accessor (artifact frozen at 1.7.3 upstream, now pinned explicitly via the version catalog) and `components.resources` (now a direct catalog dependency).
- **fix(jackson)** — `setSerializationInclusion` → `setDefaultPropertyInclusion` (verified non-deprecated equivalent in jackson-databind, identical semantics), and explicit `@param:JsonProperty` use-site targets on the OCMF/Github DTOs so the upcoming Kotlin annotation-target default change can't alter serialization.
- **fix(compose): Preview** — desktop `Preview` annotation → multiplatform `androidx.compose.ui.tooling.preview.Preview` (same artifact, import swap only).
- **fix(compose): SVG icons** — `painterResource(String)` is deprecated; icons load by dynamic string path from the app module's classpath, so this adds a `svgPainterResource` helper backed by `decodeToSvgPainter` (the documented classpath-loading replacement) instead of migrating to generated `Res` accessors.
- **fix(compose): clipboard / ClickableText** — `LocalClipboardManager` → `LocalClipboard` with suspend `setClipEntry`; `ClickableText` → `Text` + `clickable` (click handler never used the character offset).
- **fix(exposed)** — `createMissingTablesAndColumns` → `SchemaUtils.create` + executing `addMissingColumnsStatements`, preserving the exact additive behavior (never drops).

Also bumps Kover 0.9.7 → 0.9.9, which fixes the Gradle 10 "Project object as a dependency notation" deprecation coming from the Kover plugin internals (was already committed to main as part of the dep upgrade commit).

## Test plan

- [x] `./gradlew :common:compileKotlinJvm :v16:compileKotlinJvm :common:compileTestKotlinJvm` — zero warnings
- [x] `./gradlew ktlintCheck` — clean
- [ ] Smoke-test the app: icon rendering (SVG loader), copy-identity click (clipboard), previous-message click in Send Message window, DB schema creation on first launch