### PR TITLE
fix: stop duplicate connect chains looping a charge point

### DIFF
--- a/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/connection/ChargePointConnection.kt
+++ b/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/connection/ChargePointConnection.kt
@@ -8,6 +8,7 @@ import com.monta.ocpp.emulator.chargepoint.service.ChargePointService
 import com.monta.ocpp.emulator.common.idValue
 import com.monta.ocpp.emulator.common.util.MontaSerialization
 import com.monta.ocpp.emulator.common.util.injectAnywhere
+import com.monta.ocpp.emulator.common.util.launchThread
 import com.monta.ocpp.emulator.interceptor.MessageInterceptor
 import com.monta.ocpp.emulator.logger.GlobalLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -17,7 +18,11 @@ import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.util.collections.*
 import io.ktor.websocket.*
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -51,6 +56,11 @@ class ChargePointConnection(
     private val totalLatencyNanos = AtomicLong(0L)
     private val messageCount = AtomicInteger(0)
 
+    private val chainLock = Any()
+
+    private var connectionJob: Job? = null
+    private var connectedAtNanos: Long? = null
+
     val chargePoint: ChargePointDAO
         get() = chargePointService.getById(chargePointId)
 
@@ -62,6 +72,7 @@ class ChargePointConnection(
         try {
             createConnection(isReconnecting)
         } catch (exception: WebSocketException) {
+            currentCoroutineContext().ensureActive()
             val isAuthError = exception.message?.contains("401") == true
             // Failed to connect at all, so lets try reconnecting
             handleReconnection(
@@ -70,6 +81,7 @@ class ChargePointConnection(
                 additionalInfo = if (!isAuthError) exception.message else null,
             )
         } catch (exception: Exception) {
+            currentCoroutineContext().ensureActive()
             logger.warn(exception) { "error connecting" }
             // Failed to connect at all, so lets try reconnecting
             handleReconnection(
@@ -110,8 +122,8 @@ class ChargePointConnection(
 
             // Yes we should automatically reconnect on failure
             reconnect.set(true)
-            // Set our connection attempts to 3 (used for the backoff calculation)
-            connectionAttempts = 0
+            // Only reset the backoff once the connection has proven stable
+            connectedAtNanos = System.nanoTime()
             // Set our charge point as connected
             chargePointService.update(chargePoint) {
                 this.connected = true
@@ -200,14 +212,46 @@ class ChargePointConnection(
         websocketSession?.close(closeReason)
     }
 
-    suspend fun reconnect(
+    // Only one connect/retry chain at a time, the client keys its sessions by identity so a
+    // second chain just fights the first one over the same slot
+    fun start(
+        block: suspend () -> Unit,
+    ): Boolean {
+        synchronized(chainLock) {
+            if (connectionJob?.isActive == true) {
+                return false
+            }
+            connectionJob = launchThread(block = block)
+        }
+        return true
+    }
+
+    suspend fun stop(
+        closeReason: CloseReason = CloseReason(CloseReason.Codes.NORMAL, ""),
+    ) {
+        // Say goodbye first, cancelling closes the socket and the status notification
+        // would have nowhere to go
+        disconnect(closeReason)
+        // A chain already asleep in its backoff never sees the flag disconnect() clears
+        synchronized(chainLock) { connectionJob }?.cancelAndJoin()
+    }
+
+    fun restart(
         delayInSeconds: Int,
         closeReason: CloseReason = CloseReason(CloseReason.Codes.NORMAL, ""),
     ) {
-        GlobalLogger.info(chargePoint, "Reconnecting after $delayInSeconds seconds")
-        disconnect(closeReason)
-        delay(delayInSeconds.toLong() * 1000)
-        connect(true)
+        synchronized(chainLock) {
+            val previous = connectionJob
+            connectionJob = launchThread {
+                GlobalLogger.info(chargePoint, "Reconnecting after $delayInSeconds seconds")
+                // Let the old chain flush what's still in flight and wind itself down,
+                // cancelling is just the backstop for when it doesn't
+                disconnect(closeReason)
+                previous?.cancelAndJoin()
+                delay(delayInSeconds.toLong() * 1000)
+                connect(true)
+            }
+        }
     }
 
     private suspend fun handleReconnection(
@@ -215,6 +259,8 @@ class ChargePointConnection(
         forceConnect: Boolean,
         additionalInfo: String?,
     ) {
+        resetBackoffIfConnectionWasStable()
+
         val backOffTime = getBackoffTime()
 
         val shouldReconnect = try {
@@ -244,6 +290,15 @@ class ChargePointConnection(
         }
     }
 
+    // A socket that opens and closes straight away isn't a success, only count one that stayed up
+    private fun resetBackoffIfConnectionWasStable() {
+        val connectedAt = connectedAtNanos ?: return
+        connectedAtNanos = null
+        if (Duration.ofNanos(System.nanoTime() - connectedAt) >= STABLE_CONNECTION_DURATION) {
+            connectionAttempts = 0
+        }
+    }
+
     private fun getBackoffTime(): Int {
         val attempts = connectionAttempts++
 
@@ -254,5 +309,9 @@ class ChargePointConnection(
                 b = 1,
             ),
         )
+    }
+
+    private companion object {
+        private val STABLE_CONNECTION_DURATION: Duration = Duration.ofSeconds(30)
     }
 }

--- a/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/connection/ConnectionManager.kt
+++ b/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/v16/connection/ConnectionManager.kt
@@ -7,6 +7,7 @@ import com.monta.ocpp.emulator.v16.SchedulerService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.joinAll
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Singleton
 
 @Singleton
@@ -17,27 +18,26 @@ class ConnectionManager(
 
     private val logger = KotlinLogging.logger {}
 
-    private val chargePointSchedulers: MutableMap<Long, SchedulerService?> = mutableMapOf()
-    private val chargePointConnections: MutableMap<Long, ChargePointConnection?> = mutableMapOf()
+    private val chargePointSchedulers = ConcurrentHashMap<Long, SchedulerService>()
+    private val chargePointConnections = ConcurrentHashMap<Long, ChargePointConnection>()
 
     fun connect(
         chargePointId: Long,
     ) {
-        val isConnected = chargePointConnections[chargePointId]?.chargePoint?.connected
-
-        if (isConnected == true) {
-            return
+        // Claim the charge point on the calling thread, the persisted connected flag is false
+        // for the whole of every reconnect backoff so it can't guard this
+        val chargePointConnection = chargePointConnections.computeIfAbsent(chargePointId) {
+            ChargePointConnection(it)
         }
 
-        launchThread {
+        val started = chargePointConnection.start {
             logger.info { "Connecting chargePointId=$chargePointId" }
-            //
             chargePointRepository.clearChargePointBootStatus(chargePointId)
-            // Create a new connection and add it to the map
-            chargePointConnections[chargePointId]?.disconnect()
-            chargePointConnections[chargePointId] = null
-            chargePointConnections[chargePointId] = ChargePointConnection(chargePointId)
-            chargePointConnections[chargePointId]?.connect()
+            chargePointConnection.connect()
+        }
+
+        if (!started) {
+            return
         }
 
         getSchedulingService(chargePointId, true)?.start()
@@ -48,7 +48,7 @@ class ConnectionManager(
     }
 
     suspend fun disconnectAll() {
-        chargePointConnections.mapNotNull { (chargePointId, _) ->
+        chargePointConnections.keys.mapNotNull { chargePointId ->
             disconnect(chargePointId)
         }.joinAll()
     }
@@ -56,13 +56,13 @@ class ConnectionManager(
     fun disconnect(
         chargePointId: Long,
     ): Job? {
-        return chargePointConnections[chargePointId]?.let { chargePointConnection ->
+        // Release the claim on the calling thread so a later connect() is admitted
+        return chargePointConnections.remove(chargePointId)?.let { chargePointConnection ->
             logger.info { "Disconnecting chargePointId=$chargePointId" }
             launchThread {
                 chargePointRepository.clearChargePointBootStatus(chargePointId)
                 getSchedulingService(chargePointId)?.stop()
-                chargePointConnection.disconnect()
-                chargePointConnections.remove(chargePointId)
+                chargePointConnection.stop()
             }
         }
     }
@@ -72,10 +72,8 @@ class ConnectionManager(
         delayInSeconds: Int,
     ) {
         chargePointConnections[chargePointId]?.let { chargePointConnection ->
-            launchThread {
-                logger.info { "Reconnecting chargePointId=$chargePointId" }
-                chargePointConnection.reconnect(delayInSeconds)
-            }
+            logger.info { "Reconnecting chargePointId=$chargePointId" }
+            chargePointConnection.restart(delayInSeconds)
         }
     }
 
@@ -84,8 +82,8 @@ class ConnectionManager(
         create: Boolean = false,
     ): SchedulerService? {
         return if (create) {
-            chargePointSchedulers.getOrPut(chargePointId) {
-                SchedulerService(chargePointId)
+            chargePointSchedulers.computeIfAbsent(chargePointId) {
+                SchedulerService(it)
             }
         } else {
             chargePointSchedulers[chargePointId]


### PR DESCRIPTION
# Intent

## What should this change accomplish?
Hi there, thank you for open sourcing this emulator / simulator, it's been really useful! I ran into an issue with the latest version so here's a small PR. Connecting a mock chargepoint to our own CSMS (not Monta's) put the station into an endless connect / disconnect loop on boot. Our CSMS is 1.6 conformant (but NOT certified) so we don't believe it's that. The intent of this fix is that a charge point never ends up with two connect / retry chains on the same identity, and that a failing connection backs off instead of pinging the CSMS once a second infinitely (I know it says attempts = 3 in the original comment but that's not what it did).

- Done when connect() on a charge point that's already connecting, connected, or asleep in a backoff doesn't start a second chain
- Done when disconnecting stops a chain that's already asleep in its backoff so the station goes quiet
- Done when the backoff grows (2s, 4s, 8s, and so on) instead of staying pinned at 1s

## Scope / non-goals
Only touches ChargePointConnection and ConnectionManager in v16/connection. Nothing in message handling, the profiles, or the UI. I also made the chargePointSchedulers a ConcurrentHashMap since it was being written from the UI thread and read from a coroutine thread.

Doesn't touch:
- Scheduler cleanup: chargePointSchedulers entries still aren't removed on disconnect. Pre-existing, bounded by charge point count, unrelated to this bug
- No new tests: The single chain part is testable but I only saw one other test in the repo so I didn't add one

## Why?
Two bugs, both there since the first open source commit 35da373:
1. ConnectionManager.connect() guarded on the persisted connected flag, which is false while connecting and for all of every backoff. So a second connect() in that window got through, replaced the map entry, and left the old chain running. The client keys sessions by identity, so the two chains just took turns evicting each other
2. connectionAttempts reset the moment the socket opened instead of once it had stayed up, so any server that accepts the upgrade and then closes it pinned the backoff at 2^0 = 1s

Both only became reachable in v2.6.0, commit d26f300 wrapped the StatusNotification send in disconnect() in a try / catch. That send is the first line of the method, so before #73 an IllegalStateException there killed the rest of disconnect() and its callers, including reconnect() before it got to connect(true). That exception was accidentally acting as a brake on the whole reconnect path. Fixing it was right but then brought this issue up, and maybe didn't appear with the Monta CSMS

## How was it built and verified?
This PR was written by me but I used Claude Opus 5 to help write this code since I'm learning Kotlin. 

`./gradlew ktlintCheck` and `./gradlew :app:jvmTest` both pass. Also ran `./gradlew :app:run` against our Centro CSMS.

**Before**
<img width="1494" height="748" alt="Before screenshot" src="https://github.com/user-attachments/assets/f9a3c0df-98c0-443f-8fd7-08829fe953a9" />

**After**
<img width="1193" height="757" alt="After screenshot" src="https://github.com/user-attachments/assets/e744319d-fd51-40d9-968f-2be36e72eeab" />

## Context

`NOJIRA`