### PR TITLE
chore: Add 'edited' on the pull request trigger types [NOJIRA]

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,8 @@
 name: Pull Request Workflow
 
-on: [ pull_request ]
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, edited ]
 
 jobs:
   test:


### PR DESCRIPTION
This [PR#111](https://github.com/monta-app/ocpp-emulator/pull/111) will not trigger workflow actions on an updated PR title - meaning it will fail even after the title has been corrected.

Listing the 'edited' type besides the default are required for this to work
