### PR TITLE
chore: Skip the uploading of code coverage on the PR [NOJIRA]

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,7 @@ jobs:
     uses: monta-app/github-workflows/.github/workflows/pull-request-kotlin.yml@main
     with:
       skip-sonar: true
+      skip-code-coverage-on-pr: true
       java-version: "25"
       architecture: "arm64"
       gradle-module: "app"


### PR DESCRIPTION
This will fail on PRs from forked repositories.

See details in https://github.com/monta-app/github-workflows/pull/331
