### PR TITLE
refactor(engine): add EmulatorEngine connection-control facade and route UI through it

### DIFF
--- a/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/App.kt
+++ b/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/App.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.window.isTraySupported
 import com.monta.ocpp.emulator.designsystem.ui.component.MontaTray
 import com.monta.ocpp.emulator.interceptor.ui.EditMessageWindow
 import com.monta.ocpp.emulator.interceptor.ui.SendMessageWindow
-import com.monta.ocpp.emulator.ocpp.v16.connection.ConnectionManager
+import com.monta.ocpp.emulator.ocpp.core.service.EmulatorEngine
 import com.monta.ocpp.emulator.platform.analytics.service.AnalyticsHelper
 import com.monta.ocpp.emulator.platform.database.service.DatabaseService
 import com.monta.ocpp.emulator.platform.util.injectAnywhere
@@ -41,8 +41,8 @@ fun main() {
         Runtime.getRuntime().addShutdownHook(object : Thread() {
             override fun run() {
                 runBlocking {
-                    val connectionManager: ConnectionManager by injectAnywhere()
-                    connectionManager.disconnectAll()
+                    val emulatorEngine: EmulatorEngine by injectAnywhere()
+                    emulatorEngine.disconnectAll()
                 }
             }
         })

--- a/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/connector/ui/ConnectorCard.kt
+++ b/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/connector/ui/ConnectorCard.kt
@@ -34,9 +34,9 @@ import com.monta.ocpp.emulator.designsystem.ui.component.toAmpString
 import com.monta.ocpp.emulator.designsystem.ui.component.toKilowattString
 import com.monta.ocpp.emulator.designsystem.ui.component.toReadable
 import com.monta.ocpp.emulator.designsystem.ui.component.wattToKilowattString
+import com.monta.ocpp.emulator.ocpp.core.service.EmulatorEngine
 import com.monta.ocpp.emulator.ocpp.v16.extension.setMaxVehicleRate
 import com.monta.ocpp.emulator.ocpp.v16.extension.setNumberPhases
-import com.monta.ocpp.emulator.ocpp.v16.extension.stopActiveTransactions
 import com.monta.ocpp.emulator.platform.database.extension.idValue
 import com.monta.ocpp.emulator.platform.util.injectAnywhere
 import com.monta.ocpp.emulator.platform.util.launchThread
@@ -52,6 +52,7 @@ fun ConnectorCard(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val chargePointConnectorService: ChargePointConnectorService by injectAnywhere()
+    val emulatorEngine: EmulatorEngine by injectAnywhere()
 
     var connector: ChargePointConnectorDAO by remember(initConnector.idValue) {
         mutableStateOf(initConnector)
@@ -178,7 +179,9 @@ fun ConnectorCard(
                 OutlineButton(
                     onClick = {
                         launchThread {
-                            connector.stopActiveTransactions(
+                            emulatorEngine.stopTransaction(
+                                chargePointId = connector.chargePointId(),
+                                connectorPosition = connector.position,
                                 reason = Reason.Local,
                                 endReasonDescription = "Stopped by user",
                             )

--- a/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/core/ui/component/ChargePointConnectionButton.kt
+++ b/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/core/ui/component/ChargePointConnectionButton.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.Modifier
 import com.monta.ocpp.emulator.chargepoint.core.entity.ChargePointDAO
 import com.monta.ocpp.emulator.designsystem.ui.component.MontaStateIcon
 import com.monta.ocpp.emulator.designsystem.ui.component.TextTooltip
-import com.monta.ocpp.emulator.ocpp.v16.connection.ConnectionManager
+import com.monta.ocpp.emulator.ocpp.core.service.EmulatorEngine
 import com.monta.ocpp.emulator.platform.database.extension.idValue
 import com.monta.ocpp.emulator.platform.util.injectAnywhere
 
@@ -19,7 +19,7 @@ fun ChargePointConnectionButton(
     chargePoint: ChargePointDAO,
     modifier: Modifier = Modifier,
 ) {
-    val connectionManager: ConnectionManager by injectAnywhere()
+    val emulatorEngine: EmulatorEngine by injectAnywhere()
 
     TextTooltip(
         modifier = modifier,
@@ -32,9 +32,9 @@ fun ChargePointConnectionButton(
         IconButton(
             onClick = {
                 if (chargePoint.connected) {
-                    connectionManager.disconnect(chargePoint.idValue)
+                    emulatorEngine.disconnect(chargePoint.idValue)
                 } else {
-                    connectionManager.connect(chargePoint.idValue)
+                    emulatorEngine.connect(chargePoint.idValue)
                 }
             },
         ) {

--- a/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/core/ui/detail/ChargePointPage.kt
+++ b/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/core/ui/detail/ChargePointPage.kt
@@ -40,7 +40,7 @@ import com.monta.ocpp.emulator.interceptor.ui.InterceptorConfigComponent
 import com.monta.ocpp.emulator.interceptor.ui.NavShape
 import com.monta.ocpp.emulator.navigation.model.Screen
 import com.monta.ocpp.emulator.navigation.service.Navigator
-import com.monta.ocpp.emulator.ocpp.v16.connection.ConnectionManager
+import com.monta.ocpp.emulator.ocpp.core.service.EmulatorEngine
 import com.monta.ocpp.emulator.platform.database.extension.idValue
 import com.monta.ocpp.emulator.platform.util.injectAnywhere
 import kotlinx.coroutines.flow.collectLatest
@@ -53,7 +53,7 @@ fun ChargePointPage(
     val chargePointRepository: ChargePointRepository by injectAnywhere()
 
     val coroutineScope = rememberCoroutineScope()
-    val connectionManager: ConnectionManager by injectAnywhere()
+    val emulatorEngine: EmulatorEngine by injectAnywhere()
 
     var chargePoint: ChargePointDAO? by remember { mutableStateOf(null) }
 
@@ -66,7 +66,7 @@ fun ChargePointPage(
                 chargePoint = it
             }
         }
-        connectionManager.connect(chargePointId)
+        emulatorEngine.connect(chargePointId)
     }
 
     val chargePoints by produceState(listOf<ChargePointDAO>()) {

--- a/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/core/ui/list/ChargePointTable.kt
+++ b/app/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/core/ui/list/ChargePointTable.kt
@@ -41,7 +41,7 @@ import com.monta.ocpp.emulator.designsystem.ui.component.mutedForegroundColor
 import com.monta.ocpp.emulator.designsystem.ui.component.toKilowattString
 import com.monta.ocpp.emulator.navigation.model.Screen
 import com.monta.ocpp.emulator.navigation.service.Navigator
-import com.monta.ocpp.emulator.ocpp.v16.connection.ConnectionManager
+import com.monta.ocpp.emulator.ocpp.core.service.EmulatorEngine
 import com.monta.ocpp.emulator.platform.config.model.UrlChoice
 import com.monta.ocpp.emulator.platform.database.extension.idValue
 import com.monta.ocpp.emulator.platform.util.injectAnywhere
@@ -306,8 +306,8 @@ private fun ChargePointDeleteButton(
             DestructiveButton(
                 onClick = {
                     launchThread {
-                        val connectionManager: ConnectionManager by injectAnywhere()
-                        connectionManager.disconnect(chargePoint.idValue)
+                        val emulatorEngine: EmulatorEngine by injectAnywhere()
+                        emulatorEngine.disconnect(chargePoint.idValue)
                         transaction {
                             chargePoint.delete()
                             chargePoint.connectors.forEach { connector ->

--- a/engine/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/connector/exception/ChargePointConnectorNotFoundException.kt
+++ b/engine/src/jvmMain/kotlin/com/monta/ocpp/emulator/chargepoint/connector/exception/ChargePointConnectorNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.monta.ocpp.emulator.chargepoint.connector.exception
+
+class ChargePointConnectorNotFoundException(
+    chargePointId: Long,
+    connectorPosition: Int,
+) : Exception("No connector at position $connectorPosition for charge point $chargePointId")

--- a/engine/src/jvmMain/kotlin/com/monta/ocpp/emulator/ocpp/core/service/DefaultEmulatorEngine.kt
+++ b/engine/src/jvmMain/kotlin/com/monta/ocpp/emulator/ocpp/core/service/DefaultEmulatorEngine.kt
@@ -1,0 +1,57 @@
+package com.monta.ocpp.emulator.ocpp.core.service
+
+import com.monta.library.ocpp.v16.core.Reason
+import com.monta.ocpp.emulator.chargepoint.connector.exception.ChargePointConnectorNotFoundException
+import com.monta.ocpp.emulator.chargepoint.connector.service.ChargePointConnectorService
+import com.monta.ocpp.emulator.ocpp.v16.connection.ConnectionManager
+import com.monta.ocpp.emulator.ocpp.v16.extension.stopActiveTransactions
+import javax.inject.Singleton
+
+/**
+ * Default [EmulatorEngine] that delegates to the existing engine components. Registered by classpath
+ * scanning via the `@Singleton` annotation, so [com.monta.ocpp.emulator.EngineKoinModule]'s
+ * `@ComponentScan` picks it up and auto-binds it to [EmulatorEngine] — mirroring how the other
+ * engine services are wired.
+ */
+@Singleton
+class DefaultEmulatorEngine(
+    private val connectionManager: ConnectionManager,
+    private val chargePointConnectorService: ChargePointConnectorService,
+) : EmulatorEngine {
+
+    override fun connect(
+        chargePointId: Long,
+    ) {
+        connectionManager.connect(chargePointId)
+    }
+
+    override fun disconnect(
+        chargePointId: Long,
+    ) {
+        connectionManager.disconnect(chargePointId)
+    }
+
+    override suspend fun disconnectAll() {
+        connectionManager.disconnectAll()
+    }
+
+    override suspend fun stopTransaction(
+        chargePointId: Long,
+        connectorPosition: Int,
+        reason: Reason,
+        endReasonDescription: String?,
+    ) {
+        val connector = chargePointConnectorService.get(
+            chargePointId = chargePointId,
+            connectorId = connectorPosition,
+        ) ?: throw ChargePointConnectorNotFoundException(
+            chargePointId = chargePointId,
+            connectorPosition = connectorPosition,
+        )
+
+        connector.stopActiveTransactions(
+            reason = reason,
+            endReasonDescription = endReasonDescription,
+        )
+    }
+}

--- a/engine/src/jvmMain/kotlin/com/monta/ocpp/emulator/ocpp/core/service/EmulatorEngine.kt
+++ b/engine/src/jvmMain/kotlin/com/monta/ocpp/emulator/ocpp/core/service/EmulatorEngine.kt
@@ -1,0 +1,39 @@
+package com.monta.ocpp.emulator.ocpp.core.service
+
+import com.monta.library.ocpp.v16.core.Reason
+
+/**
+ * Headless entry point for driving the emulator's connection lifecycle.
+ *
+ * This is a thin command facade over the engine's connection/transaction components so callers
+ * (the Compose UI today, tests and any future headless driver) address charge points by their
+ * numeric id without reaching into [com.monta.ocpp.emulator.ocpp.v16.connection.ConnectionManager]
+ * or the DAO extensions directly. It holds no logic of its own — every method delegates.
+ */
+interface EmulatorEngine {
+
+    /** Opens (or re-opens) the websocket connection for the given charge point. */
+    fun connect(
+        chargePointId: Long,
+    )
+
+    /** Tears down the websocket connection for the given charge point. */
+    fun disconnect(
+        chargePointId: Long,
+    )
+
+    /** Tears down every currently-tracked connection and waits for them to finish. */
+    suspend fun disconnectAll()
+
+    /**
+     * Stops every active transaction on the given connector, forwarding [reason] and
+     * [endReasonDescription] verbatim to the stop so the CSMS and the persisted transaction
+     * record the caller's intent rather than a hardcoded default.
+     */
+    suspend fun stopTransaction(
+        chargePointId: Long,
+        connectorPosition: Int,
+        reason: Reason = Reason.Local,
+        endReasonDescription: String? = null,
+    )
+}

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/ocpp/core/service/DefaultEmulatorEngineTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/ocpp/core/service/DefaultEmulatorEngineTest.kt
@@ -1,0 +1,115 @@
+package com.monta.ocpp.emulator.ocpp.core.service
+
+import com.monta.library.ocpp.v16.core.Reason
+import com.monta.ocpp.emulator.chargepoint.connector.exception.ChargePointConnectorNotFoundException
+import com.monta.ocpp.emulator.chargepoint.connector.repository.ChargePointConnectorRepository
+import com.monta.ocpp.emulator.chargepoint.connector.service.ChargePointConnectorService
+import com.monta.ocpp.emulator.chargepoint.core.entity.ChargePointDAO
+import com.monta.ocpp.emulator.chargepoint.core.model.MeterType
+import com.monta.ocpp.emulator.chargepoint.core.repository.ChargePointRepository
+import com.monta.ocpp.emulator.chargepoint.core.service.ChargePointService
+import com.monta.ocpp.emulator.chargepoint.transaction.entity.ChargePointTransactionDAO
+import com.monta.ocpp.emulator.interceptor.service.MessageInterceptor
+import com.monta.ocpp.emulator.ocpp.v16.connection.ConnectionManager
+import com.monta.ocpp.emulator.platform.database.extension.idValue
+import com.monta.ocpp.emulator.testsupport.DatabaseSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+/**
+ * Exercises the DB-backed half of [DefaultEmulatorEngine] against a throwaway SQLite database.
+ *
+ * `connect`/`disconnect`/`disconnectAll` are not covered here — they open real ktor websockets to a
+ * CSMS, which this harness deliberately does not stand up. `stopTransaction` *is* reachable: the
+ * OCPP `StopTransaction` send it triggers is wrapped in a swallowing `try/catch` in the engine, so
+ * with no live session the message send is a no-op while the persisted transaction is still closed
+ * out — which is exactly the reason/description plumbing this test asserts on.
+ */
+class DefaultEmulatorEngineTest : DatabaseSpec({
+
+    val chargePointRepository = ChargePointRepository()
+    val chargePointService = ChargePointService(chargePointRepository)
+
+    val engine = DefaultEmulatorEngine(
+        connectionManager = ConnectionManager(
+            messageInterceptor = MessageInterceptor(chargePointService),
+            chargePointRepository = chargePointRepository,
+        ),
+        chargePointConnectorService = ChargePointConnectorService(ChargePointConnectorRepository()),
+    )
+
+    fun seedChargePoint(
+        identity: String = "MEM_001",
+        connectorCount: Int = 1,
+    ): ChargePointDAO {
+        return chargePointService.upsert(
+            name = "Emulator",
+            identity = identity,
+            password = null,
+            ocppUrl = "wss://example.invalid/ocpp",
+            apiUrl = "https://example.invalid",
+            firmware = "1.0.0",
+            maxKw = 22.0,
+            connectorCount = connectorCount,
+            meterType = MeterType.OCPP,
+        )
+    }
+
+    describe("stopTransaction") {
+
+        it("throws the connector-not-found exception when the charge point cannot be resolved") {
+            shouldThrow<ChargePointConnectorNotFoundException> {
+                engine.stopTransaction(
+                    chargePointId = 999_999,
+                    connectorPosition = 1,
+                )
+            }
+        }
+
+        it("throws the connector-not-found exception when the connector position cannot be resolved") {
+            val chargePoint = seedChargePoint(connectorCount = 1)
+
+            shouldThrow<ChargePointConnectorNotFoundException> {
+                engine.stopTransaction(
+                    chargePointId = chargePoint.idValue,
+                    connectorPosition = 7,
+                )
+            }
+        }
+
+        it("forwards the given reason and description through to the stopped transaction") {
+            val chargePoint = seedChargePoint(connectorCount = 1)
+
+            val transactionId = transaction {
+                val connector = chargePoint.connectors.first { it.position == 1 }
+                val activeTransaction = ChargePointTransactionDAO.newInstance(
+                    chargePoint = chargePoint,
+                    chargePointConnector = connector,
+                    externalId = 1234,
+                    idTag = "TAG",
+                )
+                connector.activeTransaction = activeTransaction
+                activeTransaction.idValue
+            }
+
+            engine.stopTransaction(
+                chargePointId = chargePoint.idValue,
+                connectorPosition = 1,
+                reason = Reason.EVDisconnected,
+                endReasonDescription = "Stopped by user",
+            )
+
+            transaction {
+                val stopped = ChargePointTransactionDAO.findById(transactionId).shouldNotBeNull()
+
+                // The reviewer's bug hardcoded Reason.Local and dropped the description; assert the
+                // caller's values survived instead of a hardcoded default.
+                stopped.endReason shouldBe Reason.EVDisconnected
+                stopped.endReasonDescription shouldBe "Stopped by user"
+                stopped.endTime.shouldNotBeNull()
+            }
+        }
+    }
+})


### PR DESCRIPTION
# Intent

## What should this change accomplish?

Reintroduce the `EmulatorEngine` facade — but as a small **connection-control command slice with real callers**, not the speculative surface that was rejected before. Every method is exercised by a UI call site migrated onto it in this same PR, and the concrete defects from the earlier review are fixed by construction.

- Done when `EmulatorEngine` exposes `connect` / `disconnect` / `disconnectAll` / `stopTransaction`, each delegating to existing engine components.
- Done when the 5 UI sites that drove connection lifecycle / stop-transaction directly now go through the facade (no dead API).
- Done when `stopTransaction` forwards the caller's `reason` + `endReasonDescription` (no hardcoded `Reason.Local`, description not dropped).
- Done when unresolved lookups throw a domain exception, addressing is consistent (`chargePointId: Long`), and the engine has a test proving the above headlessly.

## Scope / non-goals

**In scope:** the `EmulatorEngine` interface + `DefaultEmulatorEngine` (in `ocpp/core/service/`), migrating `ChargePointConnectionButton`, `ChargePointPage`, `ChargePointTable`, `App.kt`'s shutdown hook, and `ConnectorCard` onto it, a new `ChargePointConnectorNotFoundException`, and a DB-backed `DefaultEmulatorEngineTest`.

**Explicit non-goals (deferred to follow-ups):**
- No `ChargePointSummary` DTO, no `observe*` flows, no `kotlinx-serialization` — those come with the state-ownership PR that moves runtime state into the engine.
- No `reconnect` on the facade — there is **no UI caller** for it (only engine-internal), so per "every method needs a real caller" it was omitted.
- The Exposed `transaction {}`-inside-Composable read leaks (`ChargePointForm`, `ConnectorCard` reads, `ChargePointTable`) and `SendMessageWindow`/`OcppClientV16` are **not** migrated; `:app`'s temporary Exposed/OCPP deps stay until those leaks are gone.

## Why?

The module extraction gave us a headless `:engine`, but the UI still drives it by reaching into managers/DAOs directly. This facade is the narrow, UI-free contract that a future HTTP/MCP front door drives — and, more immediately, it's where connection-control behavior becomes testable without a Compose harness. Building it against real callers keeps the API honest.

## How was it built and verified?

I read the full diff. The facade only delegates; behavior at each migrated site is preserved (same args, same reason/description, same suspend/blocking context — `disconnectAll` stays `suspend`, still called inside `App.kt`'s `runBlocking` shutdown hook).

It was independently reviewed (verdict: approve-with-nits). The review specifically confirmed the transaction-boundary trap that killed the prior attempt is **absent** here: `stopTransaction` resolves the connector via `ChargePointConnectorService` and every downstream DB touch self-wraps in `transaction {}`, so the facade path is safe with no ambient transaction. The test proves this empirically — it mutates with no surrounding transaction and asserts in a separate one, using `Reason.EVDisconnected` (not `Local`) to catch any hardcoding.

Ran from repo root (JDK 25 / Gradle 9.7.1), all green:
- `./gradlew :engine:compileKotlinJvm :app:compileKotlinJvm` (`:app` auto-runs Koin `strictSafety`, so the `EmulatorEngine` binding is validated)
- `./gradlew :engine:jvmTest` (`DefaultEmulatorEngineTest`: 3 tests, 0 failures)
- `./gradlew ktlintCheck`
- `./gradlew assemble`

Not run locally: detekt (only via the `monta-app/detekt-action` CI job) and a manual emulator launch against a CSMS — `connect`/`disconnect` open real websockets and aren't unit-testable, so they're covered by the behavior-preserving migration rather than a test.

**Known, accepted nits (raised in review, deliberately not blocking):**
- The connector-not-found path now *throws* where the old in-hand-DAO code would log-and-return; in practice a no-op (the UI always has a live connector, and at the `ConnectorCard` site the throw is swallowed by `launchThread`'s exception handler).
- `disconnect` discards the `Job?` that `ConnectionManager.disconnect` returns — no caller awaits it (nor did the old code).

## Context

NOJIRA. Follow-up: the state-ownership PR (engine owns runtime state, publishes DTOs/flows) which then seals the boundary by dropping `:app`'s temporary Exposed/OCPP deps.

## Pre-merge checklist

- [ ] **Reviewed the code** — read the actual diff, not just this description, and confirmed it matches the stated Intent
- [ ] **Release risk** — evaluated failure modes, edge cases, and load
- [ ] **API scoping** — auth/operator scoping correct; no endpoint left unprotected
- [ ] **Migrations & deployment risk** — schema/env/helm changes safe and correctly ordered
- [ ] **Feature flagging** — risky or incomplete behaviour is behind a flag
- [ ] **Performance** — no new per-request queries, N+1s, or hot-path regressions
- [ ] **Tests** — the changed behaviour is actually exercised
