### PR TITLE
test(engine): add charge lifecycle and service-layer coverage [NOJIRA]

### DIFF
--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/connector/entity/ChargePointConnectorDAOTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/connector/entity/ChargePointConnectorDAOTest.kt
@@ -1,0 +1,205 @@
+package com.monta.ocpp.emulator.chargepoint.connector.entity
+
+import com.monta.library.ocpp.v16.core.ChargePointStatus
+import com.monta.ocpp.emulator.chargepoint.connector.model.CarState
+import com.monta.ocpp.emulator.chargepoint.transaction.entity.ChargePointTransactionDAO
+import com.monta.ocpp.emulator.testsupport.ChargePointFixtures
+import com.monta.ocpp.emulator.testsupport.DatabaseSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+class ChargePointConnectorDAOTest : DatabaseSpec({
+
+    fun connector(
+        maxKw: Double = 22.0,
+    ): ChargePointConnectorDAO {
+        val chargePoint = ChargePointFixtures.newChargePoint(maxKw = maxKw)
+        return ChargePointFixtures.connectorOf(chargePoint)
+    }
+
+    describe("calculateState") {
+
+        it("reports Available when no car is plugged in") {
+            val connector = connector()
+            ChargePointFixtures.setConnectorState(connector) { carState = CarState.A }
+
+            transaction { connector.calculateState() } shouldBe ChargePointStatus.Available
+        }
+
+        it("reports Available for an unplugged car even after a charge just stopped") {
+            val connector = connector()
+            ChargePointFixtures.setConnectorState(connector) { carState = CarState.A }
+
+            transaction { connector.calculateState(justStopped = true) } shouldBe ChargePointStatus.Available
+        }
+
+        it("reports Preparing for a plugged-in car with no transaction") {
+            val connector = connector()
+            ChargePointFixtures.setConnectorState(connector) { carState = CarState.B }
+
+            transaction { connector.calculateState() } shouldBe ChargePointStatus.Preparing
+        }
+
+        it("reports Finishing for a plugged-in car whose charge just stopped") {
+            val connector = connector()
+            ChargePointFixtures.setConnectorState(connector) { carState = CarState.B }
+
+            transaction { connector.calculateState(justStopped = true) } shouldBe ChargePointStatus.Finishing
+        }
+
+        it("reports Charging for a car drawing current under an active transaction") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+            ChargePointFixtures.startTransaction(chargePoint, connector)
+            ChargePointFixtures.setConnectorState(connector) {
+                carState = CarState.C
+                kw = 7.4
+            }
+
+            transaction { connector.calculateState() } shouldBe ChargePointStatus.Charging
+        }
+
+        it("reports SuspendedEV for a plugged-in car that is not drawing under an active transaction") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+            ChargePointFixtures.startTransaction(chargePoint, connector)
+            ChargePointFixtures.setConnectorState(connector) {
+                carState = CarState.B
+                kw = 7.4
+            }
+
+            transaction { connector.calculateState() } shouldBe ChargePointStatus.SuspendedEV
+        }
+
+        it("reports SuspendedEVSE when the charger itself is withholding power") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+            ChargePointFixtures.startTransaction(chargePoint, connector)
+            ChargePointFixtures.setConnectorState(connector) {
+                carState = CarState.C
+                kw = 0.0
+            }
+
+            transaction { connector.calculateState() } shouldBe ChargePointStatus.SuspendedEVSE
+        }
+
+        it("prefers SuspendedEVSE over SuspendedEV when the car is idle and the charger is at zero") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+            ChargePointFixtures.startTransaction(chargePoint, connector)
+            ChargePointFixtures.setConnectorState(connector) {
+                carState = CarState.B
+                kw = 0.0
+            }
+
+            transaction { connector.calculateState() } shouldBe ChargePointStatus.SuspendedEVSE
+        }
+
+        it("reports Preparing for a charging-ready car once its transaction is cleared") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+            ChargePointFixtures.startTransaction(chargePoint, connector)
+            ChargePointFixtures.setConnectorState(connector) {
+                carState = CarState.C
+                activeTransaction = null
+            }
+
+            transaction { connector.calculateState() } shouldBe ChargePointStatus.Preparing
+        }
+    }
+
+    describe("updateKw") {
+
+        it("draws the full rating when neither the vehicle nor a profile limits it") {
+            val connector = connector(maxKw = 22.0)
+
+            ChargePointFixtures.setConnectorState(connector) { updateKw() }
+
+            transaction { connector.kw } shouldBe (22.0 plusOrMinus 0.001)
+        }
+
+        it("is capped by what the vehicle will accept per phase") {
+            val connector = connector(maxKw = 22.0)
+
+            ChargePointFixtures.setConnectorState(connector) {
+                vehicleMaxAmpsPerPhase = 10.0
+                updateKw()
+            }
+
+            transaction { connector.kw } shouldBe (6.9 plusOrMinus 0.001)
+        }
+
+        it("is capped by a smart-charging profile below the connector rating") {
+            val connector = connector(maxKw = 22.0)
+
+            ChargePointFixtures.setConnectorState(connector) { updateKw(chargingProfileWatts = 6900.0) }
+
+            transaction { connector.kw } shouldBe (6.9 plusOrMinus 0.001)
+        }
+
+        it("ignores a profile that asks for more than the connector is rated for") {
+            val connector = connector(maxKw = 22.0)
+
+            ChargePointFixtures.setConnectorState(connector) { updateKw(chargingProfileWatts = 100_000.0) }
+
+            transaction { connector.kw } shouldBe (22.0 plusOrMinus 0.001)
+        }
+
+        it("scales down with the number of phases the vehicle is using") {
+            val connector = connector(maxKw = 22.0)
+
+            ChargePointFixtures.setConnectorState(connector) {
+                vehicleMaxAmpsPerPhase = 10.0
+                vehicleNumberPhases = 1
+                updateKw()
+            }
+
+            transaction { connector.kw } shouldBe (2.3 plusOrMinus 0.001)
+        }
+
+        it("drops to zero when a profile asks for no power at all") {
+            val connector = connector(maxKw = 22.0)
+
+            ChargePointFixtures.setConnectorState(connector) { updateKw(chargingProfileWatts = 0.0) }
+
+            transaction { connector.kw } shouldBe 0.0
+        }
+    }
+
+    describe("derived readings") {
+
+        it("converts the connector rating into watt-hours accrued per second") {
+            val connector = connector(maxKw = 22.0)
+
+            ChargePointFixtures.setConnectorState(connector) { kw = 7.2 }
+
+            transaction { connector.wattHoursPerSecond } shouldBe (2.0 plusOrMinus 0.001)
+        }
+
+        it("sums the meter across every transaction the connector has run") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+
+            transaction {
+                ChargePointTransactionDAO.newInstance(
+                    chargePoint = chargePoint,
+                    chargePointConnector = connector,
+                    externalId = 1,
+                    idTag = "TAG",
+                    endMeter = 1500.0,
+                )
+                ChargePointTransactionDAO.newInstance(
+                    chargePoint = chargePoint,
+                    chargePointConnector = connector,
+                    externalId = 2,
+                    idTag = "TAG",
+                    endMeter = 2500.0,
+                )
+            }
+
+            transaction { ChargePointConnectorDAO.findById(connector.id)?.meterWh } shouldBe
+                (4000.0 plusOrMinus 0.001)
+        }
+    }
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/core/entity/ChargePointDAOTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/core/entity/ChargePointDAOTest.kt
@@ -1,0 +1,231 @@
+package com.monta.ocpp.emulator.chargepoint.core.entity
+
+import com.monta.library.ocpp.v16.core.DataTransferRequest
+import com.monta.library.ocpp.v16.firmware.FirmwareStatusNotificationStatus
+import com.monta.ocpp.emulator.testsupport.ChargePointFixtures
+import com.monta.ocpp.emulator.testsupport.DatabaseSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+class ChargePointDAOTest : DatabaseSpec({
+
+    describe("updateConfiguration") {
+
+        it("persists the change rather than mutating the in-memory map") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction {
+                chargePoint.updateConfiguration { heartbeatInterval = 600 }
+            }
+
+            transaction {
+                ChargePointDAO.findById(chargePoint.id)?.configuration?.heartbeatInterval shouldBe 600L
+            }
+        }
+
+        it("keeps the keys it was not asked to change") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction {
+                chargePoint.updateConfiguration { heartbeatInterval = 600 }
+            }
+
+            transaction {
+                val configuration = ChargePointDAO.findById(chargePoint.id)?.configuration
+
+                configuration?.get("SupportedFeatureProfiles") shouldBe "Core"
+                configuration?.meterValueSampleInterval shouldBe 180L
+            }
+        }
+
+        it("survives repeated updates without losing earlier ones") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction {
+                chargePoint.updateConfiguration { heartbeatInterval = 600 }
+                chargePoint.updateConfiguration { freeCharging = true }
+            }
+
+            transaction {
+                val configuration = ChargePointDAO.findById(chargePoint.id)?.configuration
+
+                configuration?.heartbeatInterval shouldBe 600L
+                configuration?.freeCharging shouldBe true
+            }
+        }
+    }
+
+    describe("getConnector") {
+
+        it("returns the existing connector for a position that is already provisioned") {
+            val chargePoint = ChargePointFixtures.newChargePoint(connectorCount = 2)
+
+            val first = transaction { chargePoint.getConnector(1).id }
+            val again = transaction { chargePoint.getConnector(1).id }
+
+            again shouldBe first
+        }
+
+        it("provisions a connector on demand for a position that does not exist yet") {
+            val chargePoint = ChargePointFixtures.newChargePoint(connectorCount = 1)
+
+            transaction { chargePoint.getConnector(4) }
+
+            transaction {
+                chargePoint.connectors.map { connector -> connector.position }.sorted() shouldContainExactly
+                    listOf(1, 4)
+            }
+        }
+
+        it("gives a provisioned connector the charge point's rating and identity") {
+            val chargePoint = ChargePointFixtures.newChargePoint(connectorCount = 1, maxKw = 11.0)
+
+            transaction {
+                val connector = chargePoint.getConnector(2)
+
+                connector.maxKw shouldBe 11.0
+                connector.chargePointIdentity shouldBe "MEM_001"
+            }
+        }
+    }
+
+    describe("canPerformAction") {
+
+        it("is allowed while the firmware is idle") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction { chargePoint.canPerformAction } shouldBe true
+        }
+
+        it("is blocked mid firmware download") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction { chargePoint.firmwareStatus = FirmwareStatusNotificationStatus.Downloading }
+
+            transaction { chargePoint.canPerformAction } shouldBe false
+        }
+
+        it("is blocked mid firmware install") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction { chargePoint.firmwareStatus = FirmwareStatusNotificationStatus.Installing }
+
+            transaction { chargePoint.canPerformAction } shouldBe false
+        }
+
+        it("is allowed again once the firmware is installed") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction { chargePoint.firmwareStatus = FirmwareStatusNotificationStatus.Installed }
+
+            transaction { chargePoint.canPerformAction } shouldBe true
+        }
+    }
+
+    describe("handleDataTransferRequest") {
+
+        fun dataTransfer(
+            messageId: String,
+            data: String?,
+            vendorId: String = "com.monta",
+        ): DataTransferRequest {
+            return DataTransferRequest(
+                vendorId = vendorId,
+                messageId = messageId,
+                data = data,
+            )
+        }
+
+        it("ignores a vendor it does not speak for") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction {
+                chargePoint.handleDataTransferRequest(
+                    dataTransfer(messageId = "SoC", data = "50", vendorId = "com.example"),
+                ) shouldBe false
+            }
+        }
+
+        it("ignores a Monta message it does not recognise") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction {
+                chargePoint.handleDataTransferRequest(dataTransfer(messageId = "Unknown", data = "x")) shouldBe false
+                chargePoint.displayText shouldBe "\n\n\n\n"
+            }
+        }
+
+        it("writes the smart charging banner on the first display line") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction {
+                chargePoint.handleDataTransferRequest(
+                    dataTransfer(messageId = "SmartChargingEnabled", data = "true"),
+                ) shouldBe true
+
+                chargePoint.displayText.split("\n")[0] shouldBe "Smart Charging"
+            }
+        }
+
+        it("falls back to the plain charging banner when smart charging is off") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction {
+                chargePoint.handleDataTransferRequest(dataTransfer(messageId = "SmartChargingEnabled", data = "false"))
+
+                chargePoint.displayText.split("\n")[0] shouldBe "Charging"
+            }
+        }
+
+        it("writes each schedule field on its own line") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction {
+                chargePoint.handleDataTransferRequest(dataTransfer(messageId = "StartTime", data = "13:00"))
+                chargePoint.handleDataTransferRequest(dataTransfer(messageId = "EndTime", data = "17:00"))
+                chargePoint.handleDataTransferRequest(dataTransfer(messageId = "SoC", data = "80"))
+
+                chargePoint.displayText.split("\n") shouldContainExactly listOf(
+                    "",
+                    "",
+                    "Start at: 13:00",
+                    "Will be finished at: 17:00",
+                    "Battery at: 80%",
+                )
+            }
+        }
+
+        it("blanks every line on ClearDisplay") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction {
+                chargePoint.handleDataTransferRequest(dataTransfer(messageId = "SoC", data = "80"))
+                chargePoint.handleDataTransferRequest(dataTransfer(messageId = "ClearDisplay", data = null)) shouldBe
+                    true
+
+                chargePoint.displayText shouldBe "\n\n\n\n"
+            }
+        }
+
+        it("persists the display text so a reconnect does not blank the screen") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+
+            transaction {
+                chargePoint.handleDataTransferRequest(dataTransfer(messageId = "SoC", data = "80"))
+            }
+
+            transaction {
+                ChargePointDAO.findById(chargePoint.id)?.displayText?.split("\n")?.get(4) shouldBe "Battery at: 80%"
+            }
+        }
+    }
+
+    describe("normalizeIdentity") {
+
+        it("upper-cases and trims, because that is the stored form every query has to match") {
+            ChargePointDAO.normalizeIdentity("  mem_001  ") shouldBe "MEM_001"
+            ChargePointDAO.normalizeIdentity("MEM_001") shouldBe "MEM_001"
+        }
+    }
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/core/model/ChargePointConfigurationTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/core/model/ChargePointConfigurationTest.kt
@@ -1,0 +1,126 @@
+package com.monta.ocpp.emulator.chargepoint.core.model
+
+import com.monta.ocpp.emulator.platform.eichrecht.model.EichrechtKey
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+class ChargePointConfigurationTest : DescribeSpec({
+
+    describe("defaults") {
+
+        it("ships the OCPP 1.6 core keys a CSMS will ask for on GetConfiguration") {
+            val configuration = ChargePointConfiguration()
+
+            configuration.containsKey("HeartbeatInterval") shouldBe true
+            configuration.containsKey("MeterValuesSampledData") shouldBe true
+            configuration.containsKey("SupportedFeatureProfiles") shouldBe true
+            configuration.containsKey("ConnectionTimeOut") shouldBe true
+            configuration.containsKey(ChargePointConfiguration.freeChargingKey) shouldBe true
+        }
+
+        it("starts with free charging off and a placeholder id tag") {
+            val configuration = ChargePointConfiguration()
+
+            configuration.freeCharging shouldBe false
+            configuration.freeChargingIdTag shouldBe "FFFFFFFF"
+        }
+
+        it("samples meter values every three minutes") {
+            ChargePointConfiguration().meterValueSampleInterval shouldBe 180L
+        }
+    }
+
+    describe("meterValuesSampledData") {
+
+        it("splits the stored comma separated list into measurands") {
+            ChargePointConfiguration().meterValuesSampledData shouldContainExactly listOf(
+                "Energy.Active.Import.Register",
+                "Current.Import",
+                "Voltage",
+                "Power.Active.Import",
+                "SoC",
+            )
+        }
+
+        it("trims the whitespace a hand-typed CSMS value tends to carry") {
+            val configuration = ChargePointConfiguration()
+            configuration["MeterValuesSampledData"] = " Voltage , SoC "
+
+            configuration.meterValuesSampledData shouldContainExactly listOf("Voltage", "SoC")
+        }
+
+        it("reads as no measurands when the key was cleared") {
+            val configuration = ChargePointConfiguration()
+            configuration["MeterValuesSampledData"] = null
+
+            configuration.meterValuesSampledData shouldBe emptyList()
+        }
+    }
+
+    describe("numeric accessors") {
+
+        it("round-trip the heartbeat interval a BootNotification response set") {
+            val configuration = ChargePointConfiguration()
+            configuration.heartbeatInterval = 900
+
+            configuration["HeartbeatInterval"] shouldBe "900"
+            configuration.heartbeatInterval shouldBe 900L
+        }
+
+        it("fall back to zero rather than throwing on a value that is not a number") {
+            val configuration = ChargePointConfiguration()
+            configuration["HeartbeatInterval"] = "not-a-number"
+            configuration["MeterValueSampleInterval"] = ""
+
+            configuration.heartbeatInterval shouldBe 0L
+            configuration.meterValueSampleInterval shouldBe 0L
+        }
+    }
+
+    describe("freeCharging") {
+
+        it("round-trips through the string the CSMS sees") {
+            val configuration = ChargePointConfiguration()
+            configuration.freeCharging = true
+
+            configuration[ChargePointConfiguration.freeChargingKey] shouldBe "true"
+            configuration.freeCharging shouldBe true
+        }
+
+        it("treats any non-true value as off") {
+            val configuration = ChargePointConfiguration()
+            configuration[ChargePointConfiguration.freeChargingKey] = "yes"
+
+            configuration.freeCharging shouldBe false
+        }
+    }
+
+    describe("eichrechtKey") {
+
+        it("mints a key when none has been stored yet") {
+            val configuration = ChargePointConfiguration()
+
+            configuration.eichrechtKey.publicKey().isNotEmpty() shouldBe true
+        }
+
+        it("returns a different key each time while none is stored") {
+            val configuration = ChargePointConfiguration()
+
+            val first = configuration.eichrechtKey.publicKey()
+            val second = configuration.eichrechtKey.publicKey()
+
+            (first == second) shouldBe false
+        }
+
+        it("returns the stored key once one has been persisted") {
+            val configuration = ChargePointConfiguration()
+            val key = EichrechtKey.newInstance()
+
+            configuration.eichrechtKey = key
+
+            configuration.eichrechtKey.publicKey() shouldBe key.publicKey()
+            configuration.eichrechtKey.privateKey() shouldBe key.privateKey()
+        }
+    }
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/core/service/PreviousMessagesServiceTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/core/service/PreviousMessagesServiceTest.kt
@@ -1,0 +1,92 @@
+package com.monta.ocpp.emulator.chargepoint.core.service
+
+import com.monta.ocpp.emulator.platform.database.extension.idValue
+import com.monta.ocpp.emulator.testsupport.DatabaseSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+class PreviousMessagesServiceTest : DatabaseSpec({
+
+    val service = PreviousMessagesService()
+
+    describe("insertNewMessage") {
+
+        it("offers the most recently used message first") {
+            service.insertNewMessage("Heartbeat", "first")
+            service.insertNewMessage("Heartbeat", "second")
+            service.insertNewMessage("Heartbeat", "third")
+
+            transaction {
+                service.getAllOfMessageType("Heartbeat").map { stored -> stored.message } shouldContainExactly
+                    listOf("third", "second", "first")
+            }
+        }
+
+        it("moves a repeated message to the top instead of storing it twice") {
+            service.insertNewMessage("Heartbeat", "first")
+            service.insertNewMessage("Heartbeat", "second")
+            service.insertNewMessage("Heartbeat", "first")
+
+            transaction {
+                service.getAllOfMessageType("Heartbeat").map { stored -> stored.message } shouldContainExactly
+                    listOf("first", "second")
+            }
+        }
+
+        it("trims the message it stores, so trailing whitespace does not defeat the de-duplication") {
+            service.insertNewMessage("Heartbeat", "  padded  ")
+
+            transaction {
+                service.getAllOfMessageType("Heartbeat").single().message shouldBe "padded"
+            }
+        }
+
+        it("keeps histories for different message types apart") {
+            service.insertNewMessage("Heartbeat", "shared")
+            service.insertNewMessage("StatusNotification", "shared")
+
+            transaction {
+                service.getAllOfMessageType("Heartbeat").map { stored -> stored.message } shouldBe listOf("shared")
+                service.getAllOfMessageType("StatusNotification").map { stored -> stored.message } shouldBe
+                    listOf("shared")
+            }
+        }
+    }
+
+    describe("getAllOfMessageType") {
+
+        it("is empty for a type nothing was ever sent for") {
+            service.getAllOfMessageType("Heartbeat") shouldBe emptyList()
+        }
+    }
+
+    describe("deleteMessage") {
+
+        it("removes only the entry that was asked for") {
+            service.insertNewMessage("Heartbeat", "keep")
+            service.insertNewMessage("Heartbeat", "drop")
+            val toDelete = transaction {
+                service.getAllOfMessageType("Heartbeat").first { stored -> stored.message == "drop" }.idValue
+            }
+
+            service.deleteMessage(toDelete)
+
+            transaction {
+                service.getAllOfMessageType("Heartbeat").map { stored -> stored.message } shouldContainExactly
+                    listOf("keep")
+            }
+        }
+
+        it("is a no-op for an id that is not in the history") {
+            service.insertNewMessage("Heartbeat", "keep")
+
+            service.deleteMessage(9999)
+
+            transaction {
+                service.getAllOfMessageType("Heartbeat").map { stored -> stored.message } shouldContainExactly
+                    listOf("keep")
+            }
+        }
+    }
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/transaction/service/ChargePointTransactionServiceTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/transaction/service/ChargePointTransactionServiceTest.kt
@@ -1,0 +1,133 @@
+package com.monta.ocpp.emulator.chargepoint.transaction.service
+
+import com.monta.library.ocpp.v16.core.Reason
+import com.monta.ocpp.emulator.chargepoint.transaction.entity.ChargePointTransactionDAO
+import com.monta.ocpp.emulator.chargepoint.transaction.repository.ChargePointTransactionRepository
+import com.monta.ocpp.emulator.testsupport.ChargePointFixtures
+import com.monta.ocpp.emulator.testsupport.DatabaseSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.time.Instant
+
+class ChargePointTransactionServiceTest : DatabaseSpec({
+
+    val service = ChargePointTransactionService(ChargePointTransactionRepository())
+
+    describe("create") {
+
+        it("stores a transaction against the connector that started it") {
+            val chargePoint = ChargePointFixtures.newChargePoint(connectorCount = 2)
+            val connector = ChargePointFixtures.connectorOf(chargePoint, position = 2)
+
+            val chargePointTransaction = service.create(
+                chargePoint = chargePoint,
+                chargePointConnector = connector,
+                externalId = 4321,
+                idTag = "ABCD",
+            )
+
+            transaction {
+                chargePointTransaction.externalId shouldBe 4321
+                chargePointTransaction.idTag shouldBe "ABCD"
+                chargePointTransaction.connectorPosition shouldBe 2
+                chargePointTransaction.isOwner(chargePoint) shouldBe true
+                chargePointTransaction.isOwner(connector) shouldBe true
+            }
+        }
+
+        it("opens the transaction, so it is stoppable and counted as active") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+
+            val chargePointTransaction = service.create(
+                chargePoint = chargePoint,
+                chargePointConnector = connector,
+                externalId = 1,
+                idTag = "ABCD",
+            )
+
+            transaction {
+                chargePointTransaction.endTime.shouldBeNull()
+                chargePointTransaction.canStop() shouldBe true
+                chargePoint.getActiveTransactions().map { active -> active.externalId } shouldBe listOf(1)
+            }
+        }
+
+        it("starts the meter where it started, so an unmetered charge bills nothing") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+
+            val chargePointTransaction = service.create(
+                chargePoint = chargePoint,
+                chargePointConnector = connector,
+                externalId = 1,
+                idTag = "ABCD",
+            )
+
+            transaction {
+                chargePointTransaction.startMeter shouldBe 0.0
+                chargePointTransaction.endMeter shouldBe chargePointTransaction.startMeter
+            }
+        }
+    }
+
+    describe("getByExternalId") {
+
+        it("finds the transaction the CSMS knows about") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+            service.create(chargePoint, connector, externalId = 4321, idTag = "ABCD")
+
+            transaction { service.getByExternalId(4321)?.idTag } shouldBe "ABCD"
+        }
+
+        it("returns null for an id the CSMS never issued") {
+            ChargePointFixtures.newChargePoint()
+
+            service.getByExternalId(9999).shouldBeNull()
+        }
+    }
+
+    describe("update") {
+
+        it("applies the change and persists it") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+            service.create(chargePoint, connector, externalId = 4321, idTag = "ABCD")
+            val endTime = Instant.parse("2026-01-01T12:00:00Z")
+
+            service.update(4321) {
+                this.endTime = endTime
+                this.endReason = Reason.Remote
+                this.endMeter = 7900.0
+            }.shouldNotBeNull()
+
+            transaction {
+                val stored = ChargePointTransactionDAO.all().single()
+
+                stored.endTime shouldBe endTime
+                stored.endReason shouldBe Reason.Remote
+                stored.endMeter shouldBe 7900.0
+                stored.canStop() shouldBe false
+            }
+        }
+
+        it("is a no-op returning null when the CSMS names a transaction we never started") {
+            ChargePointFixtures.newChargePoint()
+
+            service.update(9999) { this.endMeter = 1.0 }.shouldBeNull()
+        }
+
+        it("closes the transaction out of the active set") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+            service.create(chargePoint, connector, externalId = 4321, idTag = "ABCD")
+
+            service.update(4321) { this.endTime = Instant.now() }
+
+            transaction { chargePoint.getActiveTransactions() } shouldBe emptyList()
+        }
+    }
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/txdefault/service/TxDefaultServiceTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/chargepoint/txdefault/service/TxDefaultServiceTest.kt
@@ -1,0 +1,201 @@
+package com.monta.ocpp.emulator.chargepoint.txdefault.service
+
+import com.monta.library.ocpp.common.chargingprofile.ChargingProfileKind
+import com.monta.library.ocpp.common.chargingprofile.ChargingRateUnit
+import com.monta.library.ocpp.v16.smartcharge.ChargingProfile
+import com.monta.library.ocpp.v16.smartcharge.ChargingProfilePurposeType
+import com.monta.library.ocpp.v16.smartcharge.ChargingSchedule
+import com.monta.library.ocpp.v16.smartcharge.ChargingSchedulePeriod
+import com.monta.library.ocpp.v16.smartcharge.ClearChargingProfileRequest
+import com.monta.ocpp.emulator.chargepoint.txdefault.entity.TxDefaultDAO
+import com.monta.ocpp.emulator.chargepoint.txdefault.repository.TxDefaultRepository
+import com.monta.ocpp.emulator.testsupport.ChargePointFixtures
+import com.monta.ocpp.emulator.testsupport.DatabaseSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+class TxDefaultServiceTest : DatabaseSpec({
+
+    val service = TxDefaultService(TxDefaultRepository())
+
+    fun txDefaultProfile(
+        chargingProfileId: Int? = 1,
+        stackLevel: Int = 0,
+        limit: Double = 16.0,
+        purpose: ChargingProfilePurposeType = ChargingProfilePurposeType.TxDefaultProfile,
+    ): ChargingProfile {
+        return ChargingProfile(
+            chargingProfileId = chargingProfileId,
+            stackLevel = stackLevel,
+            chargingProfilePurpose = purpose,
+            chargingProfileKind = ChargingProfileKind.Absolute,
+            chargingSchedule = ChargingSchedule(
+                chargingRateUnit = ChargingRateUnit.A,
+                chargingSchedulePeriod = listOf(
+                    ChargingSchedulePeriod(startPeriod = 0, limit = limit, numberPhases = 3),
+                ),
+            ),
+        )
+    }
+
+    describe("store") {
+
+        it("persists a TxDefault profile for a connector") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+
+            service.store(chargePoint, connector, txDefaultProfile(chargingProfileId = 7))
+
+            transaction {
+                val stored = TxDefaultDAO.all().single()
+
+                stored.chargingProfileId shouldBe 7
+                stored.txDefaultProfile.chargingSchedule?.chargingSchedulePeriod?.single()?.limit shouldBe 16.0
+            }
+        }
+
+        it("replaces a profile that is already stored under the same id") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+
+            service.store(chargePoint, connector, txDefaultProfile(chargingProfileId = 7, limit = 16.0))
+            service.store(chargePoint, connector, txDefaultProfile(chargingProfileId = 7, limit = 32.0))
+
+            transaction {
+                val stored = TxDefaultDAO.all().single()
+
+                stored.txDefaultProfile.chargingSchedule?.chargingSchedulePeriod?.single()?.limit shouldBe 32.0
+            }
+        }
+
+        it("keeps profiles with different ids side by side") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+
+            service.store(chargePoint, connector, txDefaultProfile(chargingProfileId = 1))
+            service.store(chargePoint, connector, txDefaultProfile(chargingProfileId = 2))
+
+            transaction {
+                TxDefaultDAO.all().map { stored -> stored.chargingProfileId } shouldContainExactlyInAnyOrder
+                    listOf(1, 2)
+            }
+        }
+
+        it("keeps the same profile id apart per connector") {
+            val chargePoint = ChargePointFixtures.newChargePoint(connectorCount = 2)
+            val first = ChargePointFixtures.connectorOf(chargePoint, position = 1)
+            val second = ChargePointFixtures.connectorOf(chargePoint, position = 2)
+
+            service.store(chargePoint, first, txDefaultProfile(chargingProfileId = 1))
+            service.store(chargePoint, second, txDefaultProfile(chargingProfileId = 1))
+
+            transaction { TxDefaultDAO.all().count() } shouldBe 2
+        }
+
+        it("rejects a profile that is not a TxDefaultProfile") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+
+            shouldThrow<IllegalArgumentException> {
+                service.store(
+                    chargePoint,
+                    connector,
+                    txDefaultProfile(purpose = ChargingProfilePurposeType.TxProfile),
+                )
+            }
+        }
+
+        it("rejects a profile with no id, which OCPP 1.6 requires") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+
+            shouldThrow<IllegalArgumentException> {
+                service.store(chargePoint, connector, txDefaultProfile(chargingProfileId = null))
+            }
+        }
+    }
+
+    describe("clear") {
+
+        it("clears the single profile named by id, whichever connector holds it") {
+            val chargePoint = ChargePointFixtures.newChargePoint(connectorCount = 2)
+            val first = ChargePointFixtures.connectorOf(chargePoint, position = 1)
+            val second = ChargePointFixtures.connectorOf(chargePoint, position = 2)
+            service.store(chargePoint, first, txDefaultProfile(chargingProfileId = 1))
+            service.store(chargePoint, second, txDefaultProfile(chargingProfileId = 2))
+
+            service.clear(chargePoint, null, ClearChargingProfileRequest(id = 2))
+
+            transaction {
+                TxDefaultDAO.all().map { stored -> stored.chargingProfileId } shouldContainExactlyInAnyOrder listOf(1)
+            }
+        }
+
+        it("clears only the named connector when no id is given") {
+            val chargePoint = ChargePointFixtures.newChargePoint(connectorCount = 2)
+            val first = ChargePointFixtures.connectorOf(chargePoint, position = 1)
+            val second = ChargePointFixtures.connectorOf(chargePoint, position = 2)
+            service.store(chargePoint, first, txDefaultProfile(chargingProfileId = 1))
+            service.store(chargePoint, second, txDefaultProfile(chargingProfileId = 2))
+
+            service.clear(chargePoint, second, ClearChargingProfileRequest())
+
+            transaction {
+                TxDefaultDAO.all().map { stored -> stored.chargingProfileId } shouldContainExactlyInAnyOrder listOf(1)
+            }
+        }
+
+        it("clears the whole charge point when neither id nor connector is given") {
+            val chargePoint = ChargePointFixtures.newChargePoint(connectorCount = 2)
+            val first = ChargePointFixtures.connectorOf(chargePoint, position = 1)
+            val second = ChargePointFixtures.connectorOf(chargePoint, position = 2)
+            service.store(chargePoint, first, txDefaultProfile(chargingProfileId = 1))
+            service.store(chargePoint, second, txDefaultProfile(chargingProfileId = 2))
+
+            service.clear(chargePoint, null, ClearChargingProfileRequest())
+
+            transaction { TxDefaultDAO.all().count() } shouldBe 0
+        }
+
+        it("leaves another charge point's profiles alone") {
+            val mine = ChargePointFixtures.newChargePoint(identity = "MEM_001")
+            val theirs = ChargePointFixtures.newChargePoint(identity = "MEM_002")
+            service.store(mine, ChargePointFixtures.connectorOf(mine), txDefaultProfile(chargingProfileId = 1))
+            service.store(theirs, ChargePointFixtures.connectorOf(theirs), txDefaultProfile(chargingProfileId = 1))
+
+            service.clear(mine, null, ClearChargingProfileRequest())
+
+            transaction { TxDefaultDAO.all().count() } shouldBe 1
+        }
+
+        it("does nothing when the CSMS is clearing a purpose this table does not hold") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+            service.store(chargePoint, connector, txDefaultProfile(chargingProfileId = 1))
+
+            service.clear(
+                chargePoint,
+                null,
+                ClearChargingProfileRequest(chargingProfilePurpose = ChargingProfilePurposeType.TxProfile),
+            )
+
+            transaction { TxDefaultDAO.all().count() } shouldBe 1
+        }
+
+        it("clears when the CSMS explicitly names the TxDefaultProfile purpose") {
+            val chargePoint = ChargePointFixtures.newChargePoint()
+            val connector = ChargePointFixtures.connectorOf(chargePoint)
+            service.store(chargePoint, connector, txDefaultProfile(chargingProfileId = 1))
+
+            service.clear(
+                chargePoint,
+                null,
+                ClearChargingProfileRequest(chargingProfilePurpose = ChargingProfilePurposeType.TxDefaultProfile),
+            )
+
+            transaction { TxDefaultDAO.all().count() } shouldBe 0
+        }
+    }
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/ocpp/v16/scheduler/MeterValuesGeneratorTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/ocpp/v16/scheduler/MeterValuesGeneratorTest.kt
@@ -1,0 +1,186 @@
+package com.monta.ocpp.emulator.ocpp.v16.scheduler
+
+import com.monta.ocpp.emulator.chargepoint.core.model.MeterType
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.doubles.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class MeterValuesGeneratorTest : DescribeSpec({
+
+    val watts = 6900.0
+
+    fun generate(
+        vararg measurands: String,
+        startTime: Instant? = null,
+        endMeter: Double = 0.0,
+        numberPhases: Int = 3,
+        meterType: MeterType = MeterType.OCPP,
+    ) = MeterValuesGenerator.generate(
+        meterValuesSampledData = measurands.toList(),
+        startTime = startTime,
+        endMeter = endMeter,
+        watts = watts,
+        numberPhases = numberPhases,
+        meterType = meterType,
+    )
+
+    describe("measurand selection") {
+
+        it("emits nothing when no measurands are configured") {
+            generate() shouldBe emptyList()
+        }
+
+        it("emits only the measurands that were asked for") {
+            val measurands = generate("Voltage").map { sampledValue -> sampledValue.measurand }
+
+            measurands shouldContainExactly listOf("Voltage", "Voltage", "Voltage")
+        }
+
+        it("ignores a measurand the generator does not know about") {
+            generate("Temperature") shouldBe emptyList()
+        }
+
+        it("emits the full set in a stable order") {
+            val measurands = generate(
+                "Energy.Active.Import.Register",
+                "Current.Import",
+                "Voltage",
+                "Power.Active.Import",
+                "SoC",
+                startTime = Instant.now(),
+            ).map { sampledValue -> sampledValue.measurand }
+
+            measurands shouldContainExactly listOf(
+                "Energy.Active.Import.Register",
+                "Current.Import",
+                "Current.Import",
+                "Current.Import",
+                "Voltage",
+                "Voltage",
+                "Voltage",
+                "Power.Active.Import",
+                "Power.Active.Import",
+                "Power.Active.Import",
+                "Power.Active.Import",
+                "SoC",
+            )
+        }
+    }
+
+    describe("Energy.Active.Import.Register") {
+
+        it("truncates the register to whole watt-hours for a standard meter") {
+            val sampledValue = generate(
+                "Energy.Active.Import.Register",
+                endMeter = 1234.9,
+                meterType = MeterType.OCPP,
+            ).single()
+
+            sampledValue.value shouldBe "1234"
+            sampledValue.unit shouldBe "Wh"
+        }
+
+        it("keeps one decimal and adds sub-watt-hour jitter for a high precision meter") {
+            val sampledValue = generate(
+                "Energy.Active.Import.Register",
+                endMeter = 1234.0,
+                meterType = MeterType.OcppHighPrecision,
+            ).single()
+
+            val reading = sampledValue.value.toDouble()
+
+            reading shouldBeGreaterThanOrEqual 1234.0
+            reading shouldBeLessThan 1234.5
+        }
+    }
+
+    describe("Current.Import") {
+
+        it("splits the load evenly across three phases") {
+            val values = generate("Current.Import").map { sampledValue -> sampledValue.value }
+
+            values shouldContainExactly listOf("10.0", "10.0", "10.0")
+        }
+
+        it("zeroes the phases the vehicle is not drawing on") {
+            val sampledValues = generate("Current.Import", numberPhases = 1)
+
+            sampledValues.map { sampledValue -> sampledValue.value } shouldContainExactly listOf("30.0", "0", "0")
+            sampledValues.map { sampledValue -> sampledValue.phase } shouldContainExactly listOf("L1", "L2", "L3")
+        }
+    }
+
+    describe("Power.Active.Import") {
+
+        it("reports per-phase power plus an unphased total") {
+            val sampledValues = generate("Power.Active.Import")
+
+            sampledValues.map { sampledValue -> sampledValue.phase } shouldContainExactly listOf("L1", "L2", "L3", null)
+            sampledValues.map { sampledValue -> sampledValue.value } shouldContainExactly
+                listOf("2300.0", "2300.0", "2300.0", "6900.0")
+        }
+
+        it("keeps the total consistent with the phases the vehicle is drawing on") {
+            val sampledValues = generate("Power.Active.Import", numberPhases = 1)
+
+            sampledValues.map { sampledValue -> sampledValue.value } shouldContainExactly
+                listOf("6900.0", "0", "0", "6900.0")
+        }
+    }
+
+    describe("SoC") {
+
+        it("is omitted outside a transaction, because there is no charge to report progress on") {
+            generate("SoC", startTime = null) shouldBe emptyList()
+        }
+
+        it("starts at 20 percent when the transaction has just begun") {
+            val sampledValue = generate("SoC", startTime = Instant.now()).single()
+
+            sampledValue.value shouldBe "20"
+            sampledValue.unit shouldBe "Percent"
+        }
+
+        it("climbs five percent per elapsed minute") {
+            val startTime = Instant.now().minus(10, ChronoUnit.MINUTES)
+
+            generate("SoC", startTime = startTime).single().value shouldBe "70"
+        }
+
+        it("clamps at a full battery instead of running past 100 percent") {
+            val startTime = Instant.now().minus(4, ChronoUnit.HOURS)
+
+            generate("SoC", startTime = startTime).single().value shouldBe "100"
+        }
+    }
+
+    describe("sampled value envelope") {
+
+        it("marks every value as a periodic raw sample") {
+            val sampledValues = generate(
+                "Energy.Active.Import.Register",
+                "Current.Import",
+                "Voltage",
+                "Power.Active.Import",
+                "SoC",
+                startTime = Instant.now(),
+            )
+
+            sampledValues.forEach { sampledValue ->
+                sampledValue.context shouldBe "Sample.Periodic"
+                sampledValue.format shouldBe "Raw"
+            }
+        }
+
+        it("reports every phase at nominal mains voltage") {
+            val sampledValues = generate("Voltage")
+
+            sampledValues.map { sampledValue -> sampledValue.phase } shouldContainExactly listOf("L1-N", "L2-N", "L3-N")
+            sampledValues.map { sampledValue -> sampledValue.value } shouldContainExactly listOf("230", "230", "230")
+        }
+    }
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/ocpp/v16/service/ChargeLifecycleTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/ocpp/v16/service/ChargeLifecycleTest.kt
@@ -1,0 +1,386 @@
+package com.monta.ocpp.emulator.ocpp.v16.service
+
+import com.monta.library.ocpp.v16.core.ChargePointStatus
+import com.monta.library.ocpp.v16.core.Reason
+import com.monta.ocpp.emulator.chargepoint.connector.model.CarState
+import com.monta.ocpp.emulator.chargepoint.core.model.MeterType
+import com.monta.ocpp.emulator.chargepoint.transaction.entity.ChargePointTransactionDAO
+import com.monta.ocpp.emulator.testsupport.EmulatorHarness
+import com.monta.ocpp.emulator.testsupport.EmulatorSpec
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.time.Duration.Companion.seconds
+
+class ChargeLifecycleTest : EmulatorSpec({
+
+    describe("starting a charge") {
+
+        it("tells the CSMS and records the transaction it hands back") {
+            val emulator = EmulatorHarness.start()
+
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+
+            emulator.csms.actions() shouldContain "Authorize"
+            val startTransaction = emulator.csms.lastOf("StartTransaction").shouldNotBeNull()
+            startTransaction.payload.get("idTag").asString() shouldBe "ABCD1234"
+            startTransaction.payload.get("connectorId").asInt() shouldBe 1
+
+            transaction {
+                val stored = ChargePointTransactionDAO.all().single()
+
+                stored.idTag shouldBe "ABCD1234"
+                stored.externalId shouldBe 1000
+                stored.endTime.shouldBeNull()
+            }
+        }
+
+        it("points the connector at the new transaction") {
+            val emulator = EmulatorHarness.start()
+
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+
+            transaction {
+                val connector = emulator.chargePoint().getConnector(1)
+
+                connector.activeTransaction.shouldNotBeNull()
+                connector.activeTransaction?.externalId shouldBe 1000
+            }
+        }
+
+        it("publishes the resulting connector status to the CSMS") {
+            val emulator = EmulatorHarness.start()
+
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+
+            val statuses = emulator.csms.allOf("StatusNotification").map { frame ->
+                frame.payload.get("status").asString()
+            }
+
+            statuses shouldContain "Preparing"
+            statuses shouldContain "Charging"
+        }
+
+        it("does not start a charge the CSMS refused to authorize") {
+            val emulator = EmulatorHarness.start()
+            emulator.csms.respondTo("Authorize", """{"idTagInfo":{"status":"Blocked"}}""")
+
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+
+            emulator.csms.countOf("StartTransaction") shouldBe 0
+            transaction { ChargePointTransactionDAO.all().count() } shouldBe 0
+        }
+
+        it("does not record a transaction the CSMS rejected at StartTransaction") {
+            val emulator = EmulatorHarness.start()
+            emulator.csms.respondTo(
+                "StartTransaction",
+                """{"transactionId":0,"idTagInfo":{"status":"Invalid"}}""",
+            )
+
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+
+            emulator.csms.countOf("StartTransaction") shouldBe 1
+            transaction { ChargePointTransactionDAO.all().count() } shouldBe 0
+        }
+
+        it("plugs the car in when a charge starts on an unplugged connector") {
+            val emulator = EmulatorHarness.start()
+            transaction { emulator.chargePoint().getConnector(1).carState = CarState.A }
+
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+
+            transaction { emulator.chargePoint().getConnector(1).carState } shouldBe CarState.B
+        }
+    }
+
+    describe("stopping a charge") {
+
+        it("tells the CSMS which transaction ended and why") {
+            val emulator = EmulatorHarness.start()
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+            emulator.csms.clear()
+
+            emulator.engine.stopTransaction(
+                connectorId = emulator.connectorId,
+                reason = Reason.Remote,
+                endReasonDescription = "stopped from the app",
+            )
+
+            val stopTransaction = emulator.csms.lastOf("StopTransaction").shouldNotBeNull()
+            stopTransaction.payload.get("transactionId").asInt() shouldBe 1000
+            stopTransaction.payload.get("idTag").asString() shouldBe "ABCD1234"
+            stopTransaction.payload.get("reason").asString() shouldBe "Remote"
+        }
+
+        it("closes the transaction out and clears it off the connector") {
+            val emulator = EmulatorHarness.start()
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+
+            emulator.engine.stopTransaction(
+                connectorId = emulator.connectorId,
+                reason = Reason.Remote,
+                endReasonDescription = "stopped from the app",
+            )
+
+            transaction {
+                val stored = ChargePointTransactionDAO.all().single()
+
+                stored.endTime.shouldNotBeNull()
+                stored.endReason shouldBe Reason.Remote
+                stored.endReasonDescription shouldBe "stopped from the app"
+                stored.canStop() shouldBe false
+                emulator.chargePoint().getConnector(1).activeTransaction.shouldBeNull()
+                emulator.chargePoint().getActiveTransactions() shouldBe emptyList()
+            }
+        }
+
+        it("reports the connector as Finishing once the charge is over") {
+            val emulator = EmulatorHarness.start()
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+            emulator.csms.clear()
+
+            emulator.engine.stopTransaction(connectorId = emulator.connectorId, reason = Reason.Local)
+
+            val statuses = emulator.csms.allOf("StatusNotification").map { frame ->
+                frame.payload.get("status").asString()
+            }
+
+            statuses shouldContain "Finishing"
+        }
+
+        it("sends nothing when there is no charge running") {
+            val emulator = EmulatorHarness.start()
+            emulator.csms.clear()
+
+            emulator.engine.stopTransaction(connectorId = emulator.connectorId, reason = Reason.Local)
+
+            emulator.csms.countOf("StopTransaction") shouldBe 0
+        }
+
+        it("stops the charge when the car is unplugged") {
+            val emulator = EmulatorHarness.start()
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+            emulator.csms.clear()
+
+            emulator.engine.setConnectorCarState(emulator.connectorId, CarState.A)
+
+            emulator.csms.countOf("StopTransaction") shouldBe 1
+            transaction { ChargePointTransactionDAO.all().single().endTime }.shouldNotBeNull()
+        }
+    }
+
+    describe("meter values") {
+
+        it("addresses the running transaction on the right connector") {
+            val emulator = EmulatorHarness.start(connectorCount = 2)
+            emulator.engine.authorize(emulator.connectorIds[1], "ABCD1234")
+            emulator.csms.clear()
+
+            emulator.chargePointManager.sendMeterValues(emulator.chargePoint(), connectorId = 2)
+
+            val meterValues = emulator.csms.lastOf("MeterValues").shouldNotBeNull()
+            meterValues.payload.get("connectorId").asInt() shouldBe 2
+            meterValues.payload.get("transactionId").asInt() shouldBe 1000
+        }
+
+        it("carries the measurands the charge point is configured to sample") {
+            val emulator = EmulatorHarness.start()
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+            emulator.csms.clear()
+
+            emulator.chargePointManager.sendMeterValues(emulator.chargePoint(), connectorId = 1)
+
+            val meterValues = emulator.csms.lastOf("MeterValues").shouldNotBeNull()
+            val sampledValues = meterValues.payload.get("meterValue").get(0).get("sampledValue")
+            val measurands = (0 until sampledValues.size()).map { index ->
+                sampledValues.get(index).get("measurand").asString()
+            }
+
+            measurands shouldContain "Energy.Active.Import.Register"
+            measurands shouldContain "Current.Import"
+            measurands shouldContain "Voltage"
+            measurands shouldContain "Power.Active.Import"
+            measurands shouldContain "SoC"
+        }
+
+        it("omits the transaction id when nothing is charging") {
+            val emulator = EmulatorHarness.start()
+            emulator.csms.clear()
+
+            emulator.chargePointManager.sendMeterValues(emulator.chargePoint(), connectorId = 1)
+
+            val meterValues = emulator.csms.lastOf("MeterValues").shouldNotBeNull()
+            meterValues.payload.has("transactionId") shouldBe false
+        }
+
+        it("covers every connector when the CSMS does not name one") {
+            val emulator = EmulatorHarness.start(connectorCount = 2)
+            emulator.csms.clear()
+
+            emulator.chargePointManager.sendMeterValues(emulator.chargePoint(), connectorId = null)
+
+            val connectorIds = emulator.csms.allOf("MeterValues").map { frame ->
+                frame.payload.get("connectorId").asInt()
+            }
+
+            connectorIds shouldBe listOf(1, 2)
+        }
+    }
+
+    describe("boot sequence") {
+
+        it("announces itself and comes up Available") {
+            val emulator = EmulatorHarness.start(booted = false)
+
+            emulator.chargePointManager.startBootSequence(emulator.chargePoint())
+
+            val bootNotification = emulator.csms.lastOf("BootNotification").shouldNotBeNull()
+            bootNotification.payload.get("chargePointVendor").asString() shouldBe "Monta"
+            bootNotification.payload.get("firmwareVersion").asString() shouldBe "1.0.0"
+
+            val statuses = emulator.csms.allOf("StatusNotification").map { frame ->
+                frame.payload.get("status").asString()
+            }
+            statuses shouldContain "Available"
+
+            transaction { emulator.chargePoint().bootedAt }.shouldNotBeNull()
+        }
+
+        it("adopts the heartbeat interval the CSMS asked for") {
+            val emulator = EmulatorHarness.start(booted = false)
+            emulator.csms.respondTo(
+                "BootNotification",
+                """{"status":"Accepted","currentTime":"2026-01-01T12:00:00Z","interval":42}""",
+            )
+
+            emulator.chargePointManager.startBootSequence(emulator.chargePoint())
+
+            transaction { emulator.chargePoint().configuration.heartbeatInterval } shouldBe 42L
+        }
+
+        it("publishes its meter public key so the CSMS can verify signed readings") {
+            val emulator = EmulatorHarness.start(booted = false, meterType = MeterType.Eichrecht)
+
+            emulator.chargePointManager.startBootSequence(emulator.chargePoint())
+
+            val dataTransfer = emulator.csms.lastOf("DataTransfer").shouldNotBeNull()
+            dataTransfer.payload.get("vendorId").asString() shouldBe "generalConfiguration"
+            dataTransfer.payload.get("messageId").asString() shouldBe "setMeterConfiguration"
+            dataTransfer.payload.get("data").asString().contains("publicKey") shouldBe true
+        }
+
+        it("does not come up when the CSMS rejects the boot") {
+            val emulator = EmulatorHarness.start(booted = false)
+            emulator.csms.respondTo(
+                "BootNotification",
+                """{"status":"Rejected","currentTime":"2026-01-01T12:00:00Z","interval":1}""",
+            )
+
+            emulator.chargePointManager.startBootSequence(emulator.chargePoint())
+
+            emulator.csms.actions() shouldNotContain "DataTransfer"
+            transaction { emulator.chargePoint().bootedAt }.shouldBeNull()
+        }
+    }
+
+    describe("CSMS-initiated commands") {
+
+        it("starts a charge on RemoteStartTransaction") {
+            val emulator = EmulatorHarness.start()
+
+            emulator.csms.send(
+                action = "RemoteStartTransaction",
+                payloadJson = """{"connectorId":1,"idTag":"REMOTE01"}""",
+            )
+
+            eventually(10.seconds) {
+                emulator.csms.countOf("StartTransaction") shouldBe 1
+                transaction { ChargePointTransactionDAO.all().single().idTag } shouldBe "REMOTE01"
+            }
+        }
+
+        it("stops the named charge on RemoteStopTransaction") {
+            val emulator = EmulatorHarness.start()
+            emulator.engine.authorize(emulator.connectorId, "ABCD1234")
+            emulator.csms.clear()
+
+            emulator.csms.send(
+                action = "RemoteStopTransaction",
+                payloadJson = """{"transactionId":1000}""",
+            )
+
+            eventually(10.seconds) {
+                emulator.csms.countOf("StopTransaction") shouldBe 1
+                transaction { ChargePointTransactionDAO.all().single().endTime }.shouldNotBeNull()
+            }
+        }
+
+        it("applies a ChangeConfiguration for a key the charge point knows") {
+            val emulator = EmulatorHarness.start()
+
+            emulator.csms.send(
+                action = "ChangeConfiguration",
+                payloadJson = """{"key":"MeterValueSampleInterval","value":"60"}""",
+            )
+
+            eventually(10.seconds) {
+                transaction { emulator.chargePoint().configuration.meterValueSampleInterval } shouldBe 60L
+            }
+        }
+
+        it("reports the connector status on TriggerMessage") {
+            val emulator = EmulatorHarness.start()
+            emulator.csms.clear()
+
+            emulator.csms.send(
+                action = "TriggerMessage",
+                payloadJson = """{"requestedMessage":"StatusNotification","connectorId":1}""",
+            )
+
+            eventually(10.seconds) {
+                emulator.csms.countOf("StatusNotification") shouldBe 1
+            }
+        }
+    }
+
+    describe("heartbeat") {
+
+        it("goes out on demand") {
+            val emulator = EmulatorHarness.start()
+            emulator.csms.clear()
+
+            emulator.chargePointManager.heartbeat(emulator.chargePoint())
+
+            emulator.csms.countOf("Heartbeat") shouldBe 1
+        }
+    }
+
+    describe("connector status") {
+
+        it("publishes an explicitly requested status") {
+            val emulator = EmulatorHarness.start()
+            emulator.csms.clear()
+
+            emulator.engine.setConnectorStatus(emulator.connectorId, ChargePointStatus.Unavailable)
+
+            val statusNotification = emulator.csms.lastOf("StatusNotification").shouldNotBeNull()
+            statusNotification.payload.get("status").asString() shouldBe "Unavailable"
+            statusNotification.payload.get("connectorId").asInt() shouldBe 1
+        }
+
+        it("does not re-publish a status the connector is already in") {
+            val emulator = EmulatorHarness.start()
+            emulator.engine.setConnectorStatus(emulator.connectorId, ChargePointStatus.Unavailable)
+            emulator.csms.clear()
+
+            emulator.engine.setConnectorStatus(emulator.connectorId, ChargePointStatus.Unavailable)
+
+            emulator.csms.countOf("StatusNotification") shouldBe 0
+        }
+    }
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/platform/config/model/UrlChoiceTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/platform/config/model/UrlChoiceTest.kt
@@ -1,0 +1,47 @@
+package com.monta.ocpp.emulator.platform.config.model
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class UrlChoiceTest : DescribeSpec({
+
+    describe("fromUrl") {
+
+        it("recognises each built-in environment by its OCPP URL") {
+            UrlChoice.fromUrl("ws://localhost:8000") shouldBe UrlChoice.Local
+            UrlChoice.fromUrl("wss://ocpp.dev.monta.app") shouldBe UrlChoice.Dev
+            UrlChoice.fromUrl("wss://ocpp.staging.monta.app") shouldBe UrlChoice.Staging
+            UrlChoice.fromUrl("wss://ocpp.monta.app") shouldBe UrlChoice.Production
+        }
+
+        it("falls back to Other for a custom URL") {
+            UrlChoice.fromUrl("wss://ocpp.example.invalid") shouldBe UrlChoice.Other
+        }
+
+        it("falls back to Other when nothing has been configured") {
+            UrlChoice.fromUrl(null) shouldBe UrlChoice.Other
+        }
+    }
+
+    describe("fromVehicleServiceUrl") {
+
+        it("recognises each environment that has a vehicle service") {
+            UrlChoice.fromVehicleServiceUrl("https://vehicles.dev.monta.app") shouldBe UrlChoice.Dev
+            UrlChoice.fromVehicleServiceUrl("https://vehicles.staging.monta.app") shouldBe UrlChoice.Staging
+            UrlChoice.fromVehicleServiceUrl("https://vehicles.monta.app") shouldBe UrlChoice.Production
+        }
+
+        it("falls back to Other for a custom URL") {
+            UrlChoice.fromVehicleServiceUrl("https://vehicles.example.invalid") shouldBe UrlChoice.Other
+        }
+
+        it("resolves an empty URL to Local, the first environment declaring one") {
+            UrlChoice.fromVehicleServiceUrl("") shouldBe UrlChoice.Local
+            UrlChoice.fromUrl("") shouldBe UrlChoice.Other
+        }
+
+        it("falls back to Other when nothing has been configured") {
+            UrlChoice.fromVehicleServiceUrl(null) shouldBe UrlChoice.Other
+        }
+    }
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/platform/config/service/AppConfigServiceTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/platform/config/service/AppConfigServiceTest.kt
@@ -1,0 +1,86 @@
+package com.monta.ocpp.emulator.platform.config.service
+
+import com.monta.ocpp.emulator.platform.config.entity.AppConfigDAO
+import com.monta.ocpp.emulator.platform.config.repository.AppConfigRepository
+import com.monta.ocpp.emulator.testsupport.DatabaseSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+class AppConfigServiceTest : DatabaseSpec({
+
+    val service = AppConfigService(AppConfigRepository())
+
+    describe("getOrCreate") {
+
+        it("seeds the default the first time a key is read") {
+            transaction { service.getOrCreate("ocppUrl", "wss://ocpp.monta.app").value } shouldBe
+                "wss://ocpp.monta.app"
+        }
+
+        it("does not overwrite a value the user already set") {
+            service.upsert("ocppUrl", "wss://ocpp.dev.monta.app")
+
+            transaction { service.getOrCreate("ocppUrl", "wss://ocpp.monta.app").value } shouldBe
+                "wss://ocpp.dev.monta.app"
+        }
+
+        it("seeds the row only once, so the unique key is never violated") {
+            service.getOrCreate("ocppUrl", "wss://ocpp.monta.app")
+            service.getOrCreate("ocppUrl", "wss://ocpp.monta.app")
+
+            transaction { AppConfigDAO.all().count() } shouldBe 1
+        }
+    }
+
+    describe("getByKey") {
+
+        it("returns null for a key that was never written") {
+            service.getByKey("missing").shouldBeNull()
+        }
+
+        it("returns the stored value") {
+            service.upsert("apiUrl", "https://app.monta.app")
+
+            service.getByKey("apiUrl") shouldBe "https://app.monta.app"
+        }
+
+        it("distinguishes a stored null from a missing key only by the row existing") {
+            service.upsert("apiUrl", null)
+
+            service.getByKey("apiUrl").shouldBeNull()
+            transaction { AppConfigDAO.all().count() } shouldBe 1
+        }
+    }
+
+    describe("upsert") {
+
+        it("creates the row when the key is new") {
+            service.upsert("apiUrl", "https://app.monta.app")
+
+            transaction { AppConfigDAO.all().single().key } shouldBe "apiUrl"
+        }
+
+        it("updates in place rather than adding a second row") {
+            service.upsert("apiUrl", "https://app.dev.monta.app")
+            service.upsert("apiUrl", "https://app.monta.app")
+
+            transaction { AppConfigDAO.all().count() } shouldBe 1
+            service.getByKey("apiUrl") shouldBe "https://app.monta.app"
+        }
+
+        it("writes a whole settings screen in one transaction") {
+            val written = service.upsert(
+                "ocppUrl" to "wss://ocpp.monta.app",
+                "apiUrl" to "https://app.monta.app",
+                "vehicleServiceUrl" to null,
+            )
+
+            written shouldHaveSize 3
+            service.getByKey("ocppUrl") shouldBe "wss://ocpp.monta.app"
+            service.getByKey("apiUrl") shouldBe "https://app.monta.app"
+            service.getByKey("vehicleServiceUrl").shouldBeNull()
+        }
+    }
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/platform/eichrecht/service/EichrechtSignatureServiceTest.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/platform/eichrecht/service/EichrechtSignatureServiceTest.kt
@@ -1,0 +1,213 @@
+package com.monta.ocpp.emulator.platform.eichrecht.service
+
+import com.monta.ocpp.emulator.platform.eichrecht.model.EichrechtKey
+import com.monta.ocpp.emulator.platform.eichrecht.model.OCMFReading
+import com.monta.ocpp.emulator.platform.util.MontaSerialization
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldMatch
+import org.bouncycastle.asn1.ASN1Integer
+import org.bouncycastle.asn1.ASN1Sequence
+import org.bouncycastle.asn1.sec.SECNamedCurves
+import org.bouncycastle.crypto.params.ECDomainParameters
+import org.bouncycastle.crypto.params.ECPublicKeyParameters
+import org.bouncycastle.crypto.signers.ECDSASigner
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
+import java.nio.charset.StandardCharsets
+import java.security.KeyFactory
+import java.security.MessageDigest
+import java.security.spec.X509EncodedKeySpec
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.HexFormat
+
+class EichrechtSignatureServiceTest : DescribeSpec({
+
+    val startTime: Instant = Instant.parse("2026-01-01T12:00:00Z")
+    val endTime: Instant = Instant.parse("2026-01-01T13:30:00Z")
+
+    val service = EichrechtSignatureService(
+        chargePointIdentity = "MEM_001",
+        brand = "Monta",
+        model = "E-Emulator",
+        serial = "Emulator",
+        firmware = "1.0.0",
+    )
+
+    val key = EichrechtKey.newInstance()
+
+    fun ocmf(
+        signingKey: EichrechtKey = key,
+        transactionId: Long = 42,
+        idTag: String = "ABCD1234",
+        startMeter: Double = 1000.0,
+        endMeter: Double = 7900.0,
+    ): String {
+        return service.ocmf(
+            key = signingKey,
+            transactionId = transactionId,
+            idTag = idTag,
+            startMeter = startMeter,
+            endMeter = endMeter,
+            startTime = startTime,
+            endTime = endTime,
+        )
+    }
+
+    fun payloadOf(
+        ocmfString: String,
+    ): String {
+        return ocmfString.split("|")[1]
+    }
+
+    fun signatureDataOf(
+        ocmfString: String,
+    ): String {
+        val signatureJson = MontaSerialization.objectMapper.readTree(ocmfString.split("|")[2])
+        return signatureJson.get("SD").asText()
+    }
+
+    describe("envelope") {
+
+        it("is the three pipe-separated OCMF sections") {
+            val sections = ocmf().split("|")
+
+            sections shouldHaveSize 3
+            sections[0] shouldBe "OCMF"
+        }
+
+        it("names the signing algorithm the public key was generated for") {
+            val signatureJson = MontaSerialization.objectMapper.readTree(ocmf().split("|")[2])
+
+            signatureJson.get("SA").asText() shouldBe "ECDSA-secp256k1-SHA256"
+        }
+    }
+
+    describe("payload") {
+
+        it("carries the charge point and meter identity") {
+            val payload = MontaSerialization.objectMapper.readTree(payloadOf(ocmf()))
+
+            payload.get("FV").asText() shouldBe "1.0"
+            payload.get("GI").asText() shouldBe "Monta"
+            payload.get("MM").asText() shouldBe "E-Emulator"
+            payload.get("MS").asText() shouldBe "Emulator"
+            payload.get("CI").asText() shouldBe "MEM_001"
+        }
+
+        it("paginates by transaction so two transactions never share a record") {
+            val payload = MontaSerialization.objectMapper.readTree(payloadOf(ocmf(transactionId = 7)))
+
+            payload.get("PG").asText() shouldBe "T7"
+        }
+
+        it("records the authenticated id tag as verified RFID") {
+            val payload = MontaSerialization.objectMapper.readTree(payloadOf(ocmf(idTag = "DEADBEEF")))
+
+            payload.get("ID").asText() shouldBe "DEADBEEF"
+            payload.get("IS").asBoolean() shouldBe true
+            payload.get("IL").asText() shouldBe "VERIFIED"
+        }
+
+        it("brackets the charge with a begin and an end reading") {
+            val payload = MontaSerialization.objectMapper.readTree(
+                payloadOf(ocmf(startMeter = 1000.0, endMeter = 7900.0)),
+            )
+            val readings = payload.get("RD")
+
+            readings.size() shouldBe 2
+            readings.get(0).get("TX").asText() shouldBe "B"
+            readings.get(0).get("RV").asDouble() shouldBe 1000.0
+            readings.get(1).get("TX").asText() shouldBe "E"
+            readings.get(1).get("RV").asDouble() shouldBe 7900.0
+            readings.get(0).get("RI").asText() shouldBe "1-b:1.8.e"
+            readings.get(0).get("RU").asText() shouldBe "Wh"
+            readings.get(0).get("ST").asText() shouldBe "G"
+        }
+
+        it("is byte-for-byte reproducible, so the signature covers a stable record") {
+            payloadOf(ocmf()) shouldBe payloadOf(ocmf())
+        }
+    }
+
+    describe("signature") {
+
+        it("verifies against the public key the charge point publishes") {
+            val ocmfString = ocmf()
+
+            val curve = SECNamedCurves.getByName("secp256k1")
+            val domain = ECDomainParameters(curve.curve, curve.g, curve.n, curve.h)
+            val publicKey = KeyFactory.getInstance("ECDSA", "BC").generatePublic(
+                X509EncodedKeySpec(HexFormat.of().parseHex(key.publicKey())),
+            ) as BCECPublicKey
+
+            val derSignature = ASN1Sequence.getInstance(HexFormat.of().parseHex(signatureDataOf(ocmfString)))
+            val r = (derSignature.getObjectAt(0) as ASN1Integer).value
+            val s = (derSignature.getObjectAt(1) as ASN1Integer).value
+
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest(payloadOf(ocmfString).toByteArray(StandardCharsets.UTF_8))
+
+            val verifier = ECDSASigner()
+            verifier.init(false, ECPublicKeyParameters(publicKey.q, domain))
+
+            verifier.verifySignature(digest, r, s) shouldBe true
+        }
+
+        it("does not verify against an unrelated key") {
+            val ocmfString = ocmf(signingKey = EichrechtKey.newInstance())
+
+            val curve = SECNamedCurves.getByName("secp256k1")
+            val domain = ECDomainParameters(curve.curve, curve.g, curve.n, curve.h)
+            val publicKey = KeyFactory.getInstance("ECDSA", "BC").generatePublic(
+                X509EncodedKeySpec(HexFormat.of().parseHex(key.publicKey())),
+            ) as BCECPublicKey
+
+            val derSignature = ASN1Sequence.getInstance(HexFormat.of().parseHex(signatureDataOf(ocmfString)))
+            val r = (derSignature.getObjectAt(0) as ASN1Integer).value
+            val s = (derSignature.getObjectAt(1) as ASN1Integer).value
+
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest(payloadOf(ocmfString).toByteArray(StandardCharsets.UTF_8))
+
+            val verifier = ECDSASigner()
+            verifier.init(false, ECPublicKeyParameters(publicKey.q, domain))
+
+            verifier.verifySignature(digest, r, s) shouldBe false
+        }
+
+        it("normalises to the low half of the curve order, as OCMF verifiers expect") {
+            val curve = SECNamedCurves.getByName("secp256k1")
+            val halfOrder = curve.n.shiftRight(1)
+
+            repeat(20) { attempt ->
+                val derSignature = ASN1Sequence.getInstance(HexFormat.of().parseHex(signatureDataOf(ocmf())))
+                val s = (derSignature.getObjectAt(1) as ASN1Integer).value
+
+                (s <= halfOrder) shouldBe true
+            }
+        }
+    }
+
+    describe("reading timestamps") {
+
+        it("are ISO 8601 with millisecond resolution and a synchronisation flag") {
+            val payload = MontaSerialization.objectMapper.readTree(payloadOf(ocmf()))
+
+            payload.get("RD").get(0).get("TM").asText() shouldMatch
+                Regex("""\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2},\d{3}[+-]\d{4} S""")
+        }
+
+        it("round-trip to the instant they were formatted from, whatever the local zone is") {
+            val formatted = OCMFReading.formatReadingTime(startTime, 'S')
+            val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss,SSSZ")
+
+            val parsed = ZonedDateTime.parse(formatted.substringBefore(" "), formatter).toInstant()
+
+            parsed shouldBe startTime.truncatedTo(ChronoUnit.MILLIS)
+        }
+    }
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/ChargePointFixtures.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/ChargePointFixtures.kt
@@ -1,0 +1,71 @@
+package com.monta.ocpp.emulator.testsupport
+
+import com.monta.ocpp.emulator.chargepoint.connector.entity.ChargePointConnectorDAO
+import com.monta.ocpp.emulator.chargepoint.core.entity.ChargePointDAO
+import com.monta.ocpp.emulator.chargepoint.core.model.MeterType
+import com.monta.ocpp.emulator.chargepoint.core.repository.ChargePointRepository
+import com.monta.ocpp.emulator.chargepoint.core.service.ChargePointService
+import com.monta.ocpp.emulator.chargepoint.transaction.entity.ChargePointTransactionDAO
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+object ChargePointFixtures {
+
+    private val chargePointService = ChargePointService(ChargePointRepository())
+
+    fun newChargePoint(
+        identity: String = "MEM_001",
+        name: String = "Emulator",
+        connectorCount: Int = 1,
+        maxKw: Double = 22.0,
+        meterType: MeterType = MeterType.OCPP,
+    ): ChargePointDAO {
+        return chargePointService.upsert(
+            name = name,
+            identity = identity,
+            password = null,
+            ocppUrl = "wss://example.invalid/ocpp",
+            apiUrl = "https://example.invalid",
+            firmware = "1.0.0",
+            maxKw = maxKw,
+            connectorCount = connectorCount,
+            meterType = meterType,
+        )
+    }
+
+    fun connectorOf(
+        chargePoint: ChargePointDAO,
+        position: Int = 1,
+    ): ChargePointConnectorDAO {
+        return transaction {
+            chargePoint.connectors.first { connector -> connector.position == position }
+        }
+    }
+
+    fun startTransaction(
+        chargePoint: ChargePointDAO,
+        connector: ChargePointConnectorDAO,
+        externalId: Int = 1,
+        idTag: String = "TAG",
+    ): ChargePointTransactionDAO {
+        return transaction {
+            val chargePointTransaction = ChargePointTransactionDAO.newInstance(
+                chargePoint = chargePoint,
+                chargePointConnector = connector,
+                externalId = externalId,
+                idTag = idTag,
+            )
+            connector.activeTransaction = chargePointTransaction
+            chargePointTransaction
+        }
+    }
+
+    fun setConnectorState(
+        connector: ChargePointConnectorDAO,
+        block: ChargePointConnectorDAO.() -> Unit,
+    ): ChargePointConnectorDAO {
+        return transaction {
+            block(connector)
+            connector
+        }
+    }
+}

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/DatabaseLifecycle.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/DatabaseLifecycle.kt
@@ -1,0 +1,36 @@
+package com.monta.ocpp.emulator.testsupport
+
+import com.monta.ocpp.emulator.platform.database.service.DatabaseService
+import io.kotest.core.spec.style.DescribeSpec
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.deleteIfExists
+
+fun DescribeSpec.useThrowawayDatabase() {
+    var databaseFile: Path? = null
+    var database: Database? = null
+
+    beforeEach {
+        val file = Files.createTempFile("ocpp-emulator-test-", ".db")
+        databaseFile = file
+        database = Database.connect(
+            url = "jdbc:sqlite:${file.absolutePathString()}",
+            driver = "org.sqlite.JDBC",
+        )
+        transaction {
+            SchemaUtils.create(*DatabaseService.tables)
+        }
+    }
+
+    afterEach {
+        database?.let { connectedDatabase -> TransactionManager.closeAndUnregister(connectedDatabase) }
+        databaseFile?.deleteIfExists()
+        database = null
+        databaseFile = null
+    }
+}

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/DatabaseSpec.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/DatabaseSpec.kt
@@ -1,58 +1,10 @@
 package com.monta.ocpp.emulator.testsupport
 
-import com.monta.ocpp.emulator.platform.database.service.DatabaseService
 import io.kotest.core.spec.style.DescribeSpec
-import org.jetbrains.exposed.v1.jdbc.Database
-import org.jetbrains.exposed.v1.jdbc.SchemaUtils
-import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import java.nio.file.Files
-import java.nio.file.Path
-import kotlin.io.path.absolutePathString
-import kotlin.io.path.deleteIfExists
 
-/**
- * A [DescribeSpec] whose every leaf test gets its own empty SQLite database.
- *
- * The schema is built from [DatabaseService.tables] so it cannot drift from the one the app creates
- * on startup. Nothing is mocked: the service, the repository, the Exposed mapping and the SQLite
- * dialect all run for real, which is the point — these are the layers where a mock would assert
- * nothing.
- *
- * SQLite rather than H2 on purpose. The app ships a pinned SQLite driver and the failures worth
- * catching here are dialect- and mapping-level; H2 would hide exactly those.
- *
- * ```
- * class ExampleTest : DatabaseSpec({
- *     describe("something") { ... }
- * })
- * ```
- */
 abstract class DatabaseSpec(
     body: DescribeSpec.() -> Unit,
 ) : DescribeSpec({
-
-    var databaseFile: Path? = null
-    var database: Database? = null
-
-    beforeEach {
-        val file = Files.createTempFile("ocpp-emulator-test-", ".db")
-        databaseFile = file
-        database = Database.connect(
-            url = "jdbc:sqlite:${file.absolutePathString()}",
-            driver = "org.sqlite.JDBC",
-        )
-        transaction {
-            SchemaUtils.create(*DatabaseService.tables)
-        }
-    }
-
-    afterEach {
-        database?.let { connectedDatabase -> TransactionManager.closeAndUnregister(connectedDatabase) }
-        databaseFile?.deleteIfExists()
-        database = null
-        databaseFile = null
-    }
-
+    useThrowawayDatabase()
     body()
 })

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/EmulatorHarness.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/EmulatorHarness.kt
@@ -1,0 +1,245 @@
+package com.monta.ocpp.emulator.testsupport
+
+import com.monta.library.ocpp.common.session.OcppSessionRepository
+import com.monta.library.ocpp.common.transport.OcppSettings
+import com.monta.library.ocpp.v16.client.OcppClientV16
+import com.monta.library.ocpp.v16.client.OcppClientV16Builder
+import com.monta.ocpp.emulator.chargepoint.connector.repository.ChargePointConnectorRepository
+import com.monta.ocpp.emulator.chargepoint.connector.service.ChargePointConnectorService
+import com.monta.ocpp.emulator.chargepoint.core.entity.ChargePointDAO
+import com.monta.ocpp.emulator.chargepoint.core.model.MeterType
+import com.monta.ocpp.emulator.chargepoint.core.repository.ChargePointRepository
+import com.monta.ocpp.emulator.chargepoint.core.service.ChargePointService
+import com.monta.ocpp.emulator.chargepoint.core.service.PreviousMessagesService
+import com.monta.ocpp.emulator.chargepoint.transaction.repository.ChargePointTransactionRepository
+import com.monta.ocpp.emulator.chargepoint.transaction.service.ChargePointTransactionService
+import com.monta.ocpp.emulator.chargepoint.txdefault.repository.TxDefaultRepository
+import com.monta.ocpp.emulator.chargepoint.txdefault.service.TxDefaultService
+import com.monta.ocpp.emulator.interceptor.service.MessageInterceptor
+import com.monta.ocpp.emulator.ocpp.core.service.DefaultEmulatorEngine
+import com.monta.ocpp.emulator.ocpp.core.service.EmulatorEngine
+import com.monta.ocpp.emulator.ocpp.v16.connection.ConnectionManager
+import com.monta.ocpp.emulator.ocpp.v16.profile.ChangeConfigurationService
+import com.monta.ocpp.emulator.ocpp.v16.profile.CoreClientHandler
+import com.monta.ocpp.emulator.ocpp.v16.profile.FirmwareManagementHandler
+import com.monta.ocpp.emulator.ocpp.v16.profile.LocalAuthHandler
+import com.monta.ocpp.emulator.ocpp.v16.profile.OcppClientEventsHandler
+import com.monta.ocpp.emulator.ocpp.v16.profile.SecurityManagementHandler
+import com.monta.ocpp.emulator.ocpp.v16.profile.SmartChargingClientHandler
+import com.monta.ocpp.emulator.ocpp.v16.profile.TriggerMessageHandler
+import com.monta.ocpp.emulator.ocpp.v16.service.ChargePointManager
+import com.monta.ocpp.emulator.platform.database.extension.idValue
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+import java.time.Instant
+
+class EmulatorHarness private constructor(
+    val engine: EmulatorEngine,
+    val csms: FakeCsms,
+    val client: OcppClientV16,
+    val chargePointManager: ChargePointManager,
+    val chargePointService: ChargePointService,
+    val identity: String,
+    val chargePointId: Long,
+    val connectorIds: List<Long>,
+) {
+
+    companion object {
+
+        suspend fun start(
+            identity: String = "MEM_001",
+            connectorCount: Int = 1,
+            maxKw: Double = 22.0,
+            meterType: MeterType = MeterType.OCPP,
+            booted: Boolean = true,
+        ): EmulatorHarness {
+            val csms = FakeCsms(identity)
+            val services = EngineServices.create()
+            val client = buildOcppClient(services, csms)
+            csms.client = client
+            val emulatorEngine = buildEmulatorEngine(services)
+
+            registerGraph(services, client, emulatorEngine)
+
+            val chargePoint = seedChargePoint(services, identity, connectorCount, maxKw, meterType)
+            val chargePointId = transaction { chargePoint.idValue }
+            val connectorIds = transaction {
+                chargePoint.connectors.sortedBy { connector -> connector.position }
+                    .map { connector -> connector.idValue }
+            }
+
+            markConnectedAndSuppressAutoBoot(chargePoint)
+            client.connect(
+                identity = identity,
+                isReconnecting = false,
+                sendFrame = { message -> csms.onFrame(message) },
+                closeConnection = { },
+            )
+            if (!booted) {
+                resetToUnbooted(chargePoint, csms)
+            }
+
+            return EmulatorHarness(
+                engine = emulatorEngine,
+                csms = csms,
+                client = client,
+                chargePointManager = services.chargePointManager,
+                chargePointService = services.chargePointService,
+                identity = identity,
+                chargePointId = chargePointId,
+                connectorIds = connectorIds,
+            )
+        }
+
+        private fun buildOcppClient(
+            services: EngineServices,
+            csms: FakeCsms,
+        ): OcppClientV16 {
+            val firmwareManagementHandler = FirmwareManagementHandler()
+            return OcppClientV16Builder()
+                .settings(OcppSettings(nanoSecondDates = false))
+                .onConnect { ocppSessionInfo, reconnecting ->
+                    OcppClientEventsHandler().onConnect(ocppSessionInfo, reconnecting)
+                }
+                .onDisconnect { ocppSessionInfo ->
+                    OcppClientEventsHandler().onDisconnect(ocppSessionInfo)
+                }
+                .addSendHook { chargePointIdentity, message ->
+                    services.messageInterceptor.intercept(chargePointIdentity, message)
+                }
+                .localMode(OcppSessionRepository())
+                .addCore(CoreClientHandler())
+                .addTriggerMessage(TriggerMessageHandler())
+                .addLocalAuth(LocalAuthHandler())
+                .addSmartCharge(
+                    SmartChargingClientHandler(
+                        services.chargePointService,
+                        services.chargePointTransactionService,
+                        services.txDefaultService,
+                    ),
+                )
+                .addFirmwareManagement(firmwareManagementHandler)
+                .addSecurity(SecurityManagementHandler(firmwareManagementHandler))
+                .build()
+        }
+
+        private fun buildEmulatorEngine(
+            services: EngineServices,
+        ): EmulatorEngine {
+            return DefaultEmulatorEngine(
+                connectionManager = services.connectionManager,
+                chargePointService = services.chargePointService,
+                chargePointConnectorService = services.chargePointConnectorService,
+                chargePointRepository = services.chargePointRepository,
+                chargePointManager = services.chargePointManager,
+                previousMessagesService = services.previousMessagesService,
+            )
+        }
+
+        private fun registerGraph(
+            services: EngineServices,
+            client: OcppClientV16,
+            emulatorEngine: EmulatorEngine,
+        ) {
+            startKoin {
+                modules(
+                    module {
+                        single { client }
+                        single { services.chargePointRepository }
+                        single { services.chargePointService }
+                        single { services.chargePointConnectorService }
+                        single { services.chargePointTransactionService }
+                        single { services.txDefaultService }
+                        single { services.previousMessagesService }
+                        single { services.messageInterceptor }
+                        single { services.connectionManager }
+                        single { services.chargePointManager }
+                        single { ChangeConfigurationService() }
+                        single { emulatorEngine }
+                    },
+                )
+            }
+        }
+
+        private fun seedChargePoint(
+            services: EngineServices,
+            identity: String,
+            connectorCount: Int,
+            maxKw: Double,
+            meterType: MeterType,
+        ): ChargePointDAO {
+            return services.chargePointService.upsert(
+                name = "Emulator",
+                identity = identity,
+                password = null,
+                ocppUrl = "wss://example.invalid/ocpp",
+                apiUrl = "https://example.invalid",
+                firmware = "1.0.0",
+                maxKw = maxKw,
+                connectorCount = connectorCount,
+                meterType = meterType,
+            )
+        }
+
+        /** `onConnect` starts a boot sequence on a background thread whenever `bootedAt` is null. */
+        private fun markConnectedAndSuppressAutoBoot(
+            chargePoint: ChargePointDAO,
+        ) {
+            transaction {
+                chargePoint.connected = true
+                chargePoint.bootedAt = Instant.now()
+            }
+        }
+
+        private fun resetToUnbooted(
+            chargePoint: ChargePointDAO,
+            csms: FakeCsms,
+        ) {
+            transaction {
+                chargePoint.bootedAt = null
+            }
+            csms.clear()
+        }
+    }
+
+    val connectorId: Long
+        get() {
+            return connectorIds.first()
+        }
+
+    fun chargePoint(): ChargePointDAO {
+        return chargePointService.getById(chargePointId)
+    }
+}
+
+private class EngineServices(
+    val chargePointRepository: ChargePointRepository,
+    val chargePointService: ChargePointService,
+    val chargePointConnectorService: ChargePointConnectorService,
+    val chargePointTransactionService: ChargePointTransactionService,
+    val txDefaultService: TxDefaultService,
+    val previousMessagesService: PreviousMessagesService,
+    val messageInterceptor: MessageInterceptor,
+    val connectionManager: ConnectionManager,
+    val chargePointManager: ChargePointManager,
+) {
+    companion object {
+        fun create(): EngineServices {
+            val chargePointRepository = ChargePointRepository()
+            val chargePointService = ChargePointService(chargePointRepository)
+            val messageInterceptor = MessageInterceptor(chargePointService)
+            return EngineServices(
+                chargePointRepository = chargePointRepository,
+                chargePointService = chargePointService,
+                chargePointConnectorService = ChargePointConnectorService(ChargePointConnectorRepository()),
+                chargePointTransactionService = ChargePointTransactionService(ChargePointTransactionRepository()),
+                txDefaultService = TxDefaultService(TxDefaultRepository()),
+                previousMessagesService = PreviousMessagesService(),
+                messageInterceptor = messageInterceptor,
+                connectionManager = ConnectionManager(messageInterceptor, chargePointRepository),
+                chargePointManager = ChargePointManager(),
+            )
+        }
+    }
+}

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/EmulatorSpec.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/EmulatorSpec.kt
@@ -1,0 +1,19 @@
+package com.monta.ocpp.emulator.testsupport
+
+import io.kotest.core.spec.style.DescribeSpec
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.stopKoin
+
+abstract class EmulatorSpec(
+    body: DescribeSpec.() -> Unit,
+) : DescribeSpec({
+    useThrowawayDatabase()
+
+    afterEach {
+        if (GlobalContext.getOrNull() != null) {
+            stopKoin()
+        }
+    }
+
+    body()
+})

--- a/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/FakeCsms.kt
+++ b/engine/src/jvmTest/kotlin/com/monta/ocpp/emulator/testsupport/FakeCsms.kt
@@ -1,0 +1,110 @@
+package com.monta.ocpp.emulator.testsupport
+
+import com.monta.library.ocpp.common.serialization.Message
+import com.monta.library.ocpp.common.serialization.ParsingResult
+import com.monta.library.ocpp.v16.client.OcppClientV16
+import com.monta.ocpp.emulator.interceptor.service.MessageInterceptor
+import tools.jackson.databind.JsonNode
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+
+class FakeCsms(
+    private val identity: String,
+) {
+
+    data class Sent(
+        val uniqueId: String,
+        val action: String,
+        val payload: JsonNode,
+    )
+
+    private val serializer = MessageInterceptor.serializer
+    private val overrides = ConcurrentHashMap<String, String>()
+    private val nextTransactionId = AtomicInteger(1000)
+
+    val sent = CopyOnWriteArrayList<Sent>()
+
+    lateinit var client: OcppClientV16
+
+    fun respondTo(
+        action: String,
+        payloadJson: String,
+    ) {
+        overrides[action] = payloadJson
+    }
+
+    suspend fun onFrame(
+        rawMessage: String,
+    ) {
+        val parsed = serializer.parse(rawMessage)
+        if (parsed !is ParsingResult.Success) {
+            return
+        }
+        val message = parsed.value
+        if (message !is Message.Request) {
+            return
+        }
+
+        sent.add(Sent(uniqueId = message.uniqueId, action = message.action, payload = message.payload))
+
+        val responsePayload = overrides[message.action] ?: defaultConfirmation(message.action)
+        client.receiveMessage(identity, """[3,"${message.uniqueId}",$responsePayload]""")
+    }
+
+    suspend fun send(
+        action: String,
+        payloadJson: String = "{}",
+        uniqueId: String = UUID.randomUUID().toString(),
+    ) {
+        client.receiveMessage(identity, """[2,"$uniqueId","$action",$payloadJson]""")
+    }
+
+    fun actions(): List<String> {
+        return sent.map { frame -> frame.action }
+    }
+
+    fun countOf(
+        action: String,
+    ): Int {
+        return sent.count { frame -> frame.action == action }
+    }
+
+    fun lastOf(
+        action: String,
+    ): Sent? {
+        return sent.lastOrNull { frame -> frame.action == action }
+    }
+
+    fun allOf(
+        action: String,
+    ): List<Sent> {
+        return sent.filter { frame -> frame.action == action }
+    }
+
+    fun clear() {
+        sent.clear()
+    }
+
+    private fun defaultConfirmation(
+        action: String,
+    ): String {
+        val now = DateTimeFormatter.ISO_INSTANT.format(ZonedDateTime.now(ZoneOffset.UTC))
+        return when (action) {
+            "BootNotification" -> """{"status":"Accepted","currentTime":"$now","interval":300}"""
+            "Heartbeat" -> """{"currentTime":"$now"}"""
+            "Authorize" -> """{"idTagInfo":{"status":"Accepted"}}"""
+            "StartTransaction" -> {
+                """{"transactionId":${nextTransactionId.getAndIncrement()},"idTagInfo":{"status":"Accepted"}}"""
+            }
+
+            "StopTransaction" -> """{"idTagInfo":{"status":"Accepted"}}"""
+            "DataTransfer" -> """{"status":"Accepted"}"""
+            else -> "{}"
+        }
+    }
+}


### PR DESCRIPTION
# Intent

## What should this change accomplish?

Give `:engine` tests that exercise the behaviour users actually report bugs about — a charge that starts locally but never tells the CSMS, a transaction row left open after a stop, meter values addressed to the wrong connector — rather than only the pure helpers.

- Done when a charge can be started and stopped end to end in a test, asserting **both** what went out on the wire and what was persisted.
- Done when meter values, the boot sequence, and CSMS-initiated `RemoteStartTransaction` / `RemoteStopTransaction` / `ChangeConfiguration` / `TriggerMessage` are covered.
- Done when the service layer (`transaction`, `txdefault`, `config`, previous messages) and the connector state machine have tests.
- Done when `./gradlew :engine:jvmTest ktlintCheck` is green and repeatable — no flaky tests.

## Scope / non-goals

Test sources only. **No production code changed** — the diff touches nothing outside `engine/src/jvmTest/`.

Deliberately out of scope:

- **Injecting a `java.time.Clock`.** `SchedulerService` stays at 0% because all three of its decisions are `Duration.between(storedTimestamp, Instant.now()) < interval` gates, and the engine calls `Instant.now()` directly in ~38 places. A test clock is inert against `Instant.now()`, so covering the scheduler needs a production change. Left for a follow-up; `ChargingProfileCalculator` already shows the shape (it takes its reference time as a parameter, which is why it was the one protocol class already testable).
- **IO adapters** — `ChargePointConnection`, `ConnectionManager`, `DatabaseInitiator`, `AnalyticsHelper`. A unit test there asserts against a mock of the thing that actually breaks.
- Enum/DTO declarations, where coverage is free and proves nothing.

## Why?

`:engine` was at 25.6% line / 10.8% branch, and none of it touched the charge lifecycle. The protocol layer looked untestable because everything reaches `OcppClientV16` through `injectAnywhere()` — but the seam already exists: the emulator only reaches its socket via the `sendFrame` lambda passed to `connect()`, and inbound frames only arrive via `receiveMessage()`.

`EmulatorHarness` builds the real client with the real builder, handlers and send hook, and points `sendFrame` at an in-memory `FakeCsms`. The OCPP serialiser, profile dispatch, the interceptor hook and SQLite all run; the socket is the only substitution.

Coverage: **line 25.6% → 58.4%, branch 10.8% → 47.1%**, 190 tests. `ChargePointManager` 0% → 66%, `CoreClientHandler` 0% → 30%.

## How was it built and verified?

- `./gradlew :engine:jvmTest ktlintCheck --rerun-tasks` — 190 tests green, lint clean.
- **Mutation-checked, not just green:** inverting two assertions (`StopTransaction` reason, remote-start id tag) failed four tests — two expected, two not. That surfaced a real race: `onConnect` fires `launchThread { startBootSequence() }` when `bootedAt` is null, so the boot cases were racing a second boot sequence. Fixed in the harness (`markConnectedAndSuppressAutoBoot`), then confirmed with four consecutive clean runs.
- CSMS-initiated handlers answer and then work in `launchThread`, so those cases use Kotest `eventually { }` rather than asserting inline.

Not run against a live CSMS — the harness is deliberately in-process, and no production code changed.

## Context

`NOJIRA`. Builds on the `EmulatorEngine` facade from #125, which the lifecycle tests drive.
